### PR TITLE
Add CI Dockerfile for e2e test

### DIFF
--- a/Dockerfile.installer.ci
+++ b/Dockerfile.installer.ci
@@ -1,0 +1,27 @@
+# This Dockerfile is a used by CI to test using OpenShift Installer against an OpenStack cloud.
+# It builds an image containing the openshift-install command as well as the openstack cli.
+
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+RUN mkdir -p /go/src/github.com/openshift/
+RUN git clone https://github.com/openshift/installer /go/src/github.com/openshift/installer
+WORKDIR /go/src/github.com/openshift/installer
+RUN hack/build.sh
+
+FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
+COPY --from=registry.svc.ci.openshift.org/openshift/origin-v4.0:cli /usr/bin/oc /bin/oc
+
+RUN yum install --setopt=tsflags=nodocs -y \
+    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+    https://www.rdoproject.org/repos/rdo-release.rpm && \
+    yum update -y && \
+    yum install --setopt=tsflags=nodocs -y \
+    python-openstackclient && \
+    yum clean all && rm -rf /var/cache/yum/*
+
+RUN mkdir /output && chown 1000:1000 /output
+USER 1000:1000
+ENV PATH /bin
+ENV HOME /output
+WORKDIR /output
+ENTRYPOINT ["/bin/openshift-install"]


### PR DESCRIPTION
Adds a Dockerfile that can be used in the e2e openshift installer job to test CAPO.
