### PR TITLE
Bug 1745939: Return error if image creation fails

### DIFF
--- a/pkg/cloud/openstack/machine/actuator.go
+++ b/pkg/cloud/openstack/machine/actuator.go
@@ -344,6 +344,7 @@ func (oc *OpenstackClient) Update(ctx context.Context, cluster *clusterv1.Cluste
 			err = oc.Create(ctx, cluster, machine)
 			if err != nil {
 				klog.Errorf("create machine %s for update failed: %v", machine.ObjectMeta.Name, err)
+				return fmt.Errorf("Cannot create machine %s: %v", machine.ObjectMeta.Name, err)
 			}
 			klog.Infof("Successfully updated machine %s", currentMachine.ObjectMeta.Name)
 		}


### PR DESCRIPTION
Now if CAPO cannot create an image it ignores the error and continue operating as the creation was successful.
This patch returns the error if something wrong happens.