### PR TITLE
Bug 1746015: Return error if instance deletion fails

### DIFF
--- a/pkg/cloud/openstack/machine/actuator.go
+++ b/pkg/cloud/openstack/machine/actuator.go
@@ -326,6 +326,7 @@ func (oc *OpenstackClient) Update(ctx context.Context, cluster *clusterv1.Cluste
 		err = oc.Delete(ctx, cluster, currentMachine)
 		if err != nil {
 			klog.Errorf("delete machine %s for update failed: %v", currentMachine.ObjectMeta.Name, err)
+			return fmt.Errorf("Cannot delete machine %s: %v", currentMachine.ObjectMeta.Name, err)
 		} else {
 			instanceDeleteTimeout := getTimeout("CLUSTER_API_OPENSTACK_INSTANCE_DELETE_TIMEOUT", TimeoutInstanceDelete)
 			instanceDeleteTimeout = instanceDeleteTimeout * time.Minute


### PR DESCRIPTION
Now if CAPO cannot create an instance it ignores the error and continue operating as the deletion was successful.

This patch returns the error if something wrong happens.