### PR TITLE
Bug 1746015: provide correct API to machine serialization

### DIFF
--- a/pkg/cloud/openstack/machine/instancestatus.go
+++ b/pkg/cloud/openstack/machine/instancestatus.go
@@ -113,7 +113,7 @@ func (oc *OpenstackClient) machineInstanceStatus(machine *machinev1.Machine) (in
 
 	serializer := json.NewSerializer(json.DefaultMetaFactory, oc.scheme, oc.scheme, false)
 	var status machinev1.Machine
-	_, _, err := serializer.Decode([]byte(a), &schema.GroupVersionKind{Group: "cluster.k8s.io", Version: "v1alpha1", Kind: "Machine"}, &status)
+	_, _, err := serializer.Decode([]byte(a), &schema.GroupVersionKind{Group: "machine.openshift.io", Version: "v1beta1", Kind: "Machine"}, &status)
 	if err != nil {
 		return nil, fmt.Errorf("decoding failure: %v", err)
 	}


### PR DESCRIPTION
Now we use k8s API to create a machine that later will be deleted, but since this API is not registered in OpenShift we have an empty struct as a result.
Later the actuator will parse the providerSpec of the machine and fail because it cannot be found.

This patch changes the API correct "machine.openshift.io"