### PR TITLE
Bug 1746021: Check networks upon Machine creation

### DIFF
--- a/pkg/cloud/openstack/clients/machineservice.go
+++ b/pkg/cloud/openstack/clients/machineservice.go
@@ -276,6 +276,10 @@ func (is *InstanceService) GetAcceptableFloatingIP() (string, error) {
 	return "", fmt.Errorf("Don't have acceptable floating IP")
 }
 
+func (is *InstanceService) GetNetworkingClient() *gophercloud.ServiceClient {
+	return is.networkClient
+}
+
 // A function for getting the id of a network by querying openstack with filters
 func getNetworkIDsByFilter(is *InstanceService, opts *networks.ListOpts) ([]string, error) {
 	if opts == nil {


### PR DESCRIPTION
When creating a new `Machine`, check that the `Network` configuration
matches what is in OpenStack. If one of the given Networks or Subnets is
not found in OpenStack, return an explicit error.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1746021