### PR TITLE
Bug 1746021: Abort Instance if no valid network

### DIFF
--- a/pkg/cloud/openstack/clients/machineservice.go
+++ b/pkg/cloud/openstack/clients/machineservice.go
@@ -479,6 +479,9 @@ func (is *InstanceService) InstanceCreate(clusterName string, name string, clust
 			}
 		}
 	}
+	if len(nets) == 0 {
+		return nil, fmt.Errorf("No network was found or provided. Please check your machine configuration and try again")
+	}
 
 	clusterInfra, err := configClient.Infrastructures().Get("cluster", metav1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
The Machine service, upon machine creation, looks in OpenStack for
networks and subnets matching the Machine Networks specificiation.

Before this change, if no matching network was found, the Instance spec
was sent to OpenStack with an empty Network segment.

With this change, the Machine service returns an error to the caller if
no matching networks are found in Openstack.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1746021