### PR TITLE
Change manifests generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,9 @@ generate: manifests
 	go generate ./pkg/... ./cmd/...
 
 manifests:
-	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go crd --domain openshift.io
+	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go crd \
+	    paths=./pkg/apis/openstackproviderconfig/... \
+	    output:crd:dir=./config/crds
 
 images: openstack-cluster-api-controller manifests
 


### PR DESCRIPTION
In k8s 1.16 "--domain" option was removed from controller-gen, so now we have to explicitly specify paths to our apis and the output directory.