### PR TITLE
Bug 1769879: allow CA Cert bundles to be trusted

### DIFF
--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -38,6 +38,9 @@ type OpenstackProviderSpec struct {
 	// The name of the cloud to use from the clouds secret
 	CloudName string `json:"cloudName"`
 
+	// A plaintext string of PEM(s)
+	CertBundle string `json:"caCert,omitempty"`
+
 	// The flavor reference for the flavor for your server instance.
 	Flavor string `json:"flavor"`
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**: Adds ability to trust CA bundle to CAPO
