### PR TITLE
Bug 1769879: SSC refractor

### DIFF
--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -38,9 +38,6 @@ type OpenstackProviderSpec struct {
 	// The name of the cloud to use from the clouds secret
 	CloudName string `json:"cloudName"`
 
-	// A plaintext string of PEM(s)
-	CertBundle string `json:"caCert,omitempty"`
-
 	// The flavor reference for the flavor for your server instance.
 	Flavor string `json:"flavor"`
 

--- a/pkg/cloud/openstack/clients/machineservice.go
+++ b/pkg/cloud/openstack/clients/machineservice.go
@@ -17,11 +17,8 @@ limitations under the License.
 package clients
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/base64"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
@@ -169,16 +166,17 @@ func NewInstanceServiceFromMachine(kubeClient kubernetes.Interface, machine *mac
 			return nil, fmt.Errorf("Failed to get cloud from secret (clients/machienservice.go 150): %v", err)
 		}
 	}
-	return NewInstanceServiceFromCloud(cloud, []byte(machineSpec.CertBundle))
+	return NewInstanceServiceFromCloud(cloud)
 }
 
 func NewInstanceService() (*InstanceService, error) {
 	cloud := clientconfig.Cloud{}
-	return NewInstanceServiceFromCloud(cloud, nil)
+	return NewInstanceServiceFromCloud(cloud)
 }
 
-func NewInstanceServiceFromCloud(cloud clientconfig.Cloud, cert []byte) (*InstanceService, error) {
+func NewInstanceServiceFromCloud(cloud clientconfig.Cloud) (*InstanceService, error) {
 	clientOpts := new(clientconfig.ClientOpts)
+	var opts *gophercloud.AuthOptions
 
 	if cloud.AuthInfo != nil {
 		clientOpts.AuthInfo = cloud.AuthInfo
@@ -188,36 +186,16 @@ func NewInstanceServiceFromCloud(cloud clientconfig.Cloud, cert []byte) (*Instan
 	}
 
 	opts, err := clientconfig.AuthOptions(clientOpts)
+
 	if err != nil {
 		return nil, err
 	}
 
 	opts.AllowReauth = true
 
-	provider, err := openstack.NewClient(opts.IdentityEndpoint)
+	provider, err := openstack.AuthenticatedClient(*opts)
 	if err != nil {
-		return nil, fmt.Errorf("Create new provider client failed: %v", err)
-	}
-
-	if cert != nil {
-		certPool, err := x509.SystemCertPool()
-		if err != nil {
-			return nil, fmt.Errorf("Create system cert pool failed: %v", err)
-		}
-		certPool.AppendCertsFromPEM(cert)
-		client := http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					RootCAs: certPool,
-				},
-			},
-		}
-		provider.HTTPClient = client
-	}
-
-	err = openstack.Authenticate(provider, *opts)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to authenticate provider client: %v", err)
+		return nil, fmt.Errorf("Create providerClient err: %v", err)
 	}
 
 	identityClient, err := openstack.NewIdentityV3(provider, gophercloud.EndpointOpts{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Corrects Self Signed Certs support to pull from centralized location in the cluster, the openshift-config:cloud-provider-config configmap.
