### PR TITLE
Bug 1815029: Allow to create network ports without allowed address pairs

### DIFF
--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -121,6 +121,8 @@ type NetworkParam struct {
 	Filter Filter `json:"filter,omitempty"`
 	// Subnet within a network to use
 	Subnets []SubnetParam `json:"subnets,omitempty"`
+	// NoAllowedAddressPairs disables creation of allowed address pairs for the network ports
+	NoAllowedAddressPairs bool `json:"noAllowedAddressPairs,omitempty"`
 }
 
 type Filter struct {


### PR DESCRIPTION
This commit allows to set a flag to NetworkParameter that disables allowed address pairs creation for all network ports.
