### PR TITLE
Bug 1804596: Continue deleting the instance if its ports haven't been destroyed

### DIFF
--- a/pkg/cloud/openstack/clients/machineservice.go
+++ b/pkg/cloud/openstack/clients/machineservice.go
@@ -756,7 +756,7 @@ func (is *InstanceService) InstanceCreate(clusterName string, name string, clust
 	return serverToInstance(server), nil
 }
 
-func (is *InstanceService) deleterInstancePorts(id string) error {
+func (is *InstanceService) deleteInstancePorts(id string) error {
 	// get instance port id
 	allInterfaces, err := attachinterfaces.List(is.computeClient, id).AllPages()
 	if err != nil {
@@ -823,7 +823,7 @@ func (is *InstanceService) deleterInstancePorts(id string) error {
 }
 
 func (is *InstanceService) InstanceDelete(id string) error {
-	err := is.deleterInstancePorts(id)
+	err := is.deleteInstancePorts(id)
 	if err != nil {
 		klog.Warningf("Couldn't delete all instance %v ports: %v", id, err)
 	}

--- a/pkg/cloud/openstack/clients/machineservice.go
+++ b/pkg/cloud/openstack/clients/machineservice.go
@@ -756,7 +756,7 @@ func (is *InstanceService) InstanceCreate(clusterName string, name string, clust
 	return serverToInstance(server), nil
 }
 
-func (is *InstanceService) InstanceDelete(id string) error {
+func (is *InstanceService) deleterInstancePorts(id string) error {
 	// get instance port id
 	allInterfaces, err := attachinterfaces.List(is.computeClient, id).AllPages()
 	if err != nil {
@@ -817,6 +817,15 @@ func (is *InstanceService) InstanceDelete(id string) error {
 		if err != nil {
 			return fmt.Errorf("Error deleting the port %v", port.PortID)
 		}
+	}
+
+	return nil
+}
+
+func (is *InstanceService) InstanceDelete(id string) error {
+	err := is.deleterInstancePorts(id)
+	if err != nil {
+		klog.Warningf("Couldn't delete all instance %v ports: %v", id, err)
 	}
 
 	// delete instance


### PR DESCRIPTION
If the instance is not Active, then when we try to delete it, Neutron may fail to delete its ports, and therefore we can't delete the instance after that.

This patch accepts the fact that ports may not be removed, and continues deleting the instance anyway.
