### PR TITLE
Bug 1872080: Add Dockerfile.rhel to match build configuration in ocp-build-data

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,15 @@
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.6 AS builder
+WORKDIR /go/src/sigs.k8s.io/cluster-api-provider-openstack
+COPY . .
+
+RUN go build -o ./machine-controller-manager ./cmd/manager
+
+FROM registry.svc.ci.openshift.org/ocp/4.6:base
+RUN INSTALL_PKGS=" \
+      openssh \
+      " && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-openstack/machine-controller-manager /


### PR DESCRIPTION
**What this PR does / why we need it**:

This change adds a new Dockerfile.rhel file to control builds that
target rhel. It is inspired by the automatically generated patches which
ensure that build files match what is in the
[ocp-build-data
repository](https://github.com/openshift/ocp-build-data/tree/openshift-4.6-rhel-8/images)
used for producing release artifacts.

After this change merges, the configuration files in
https://github.com/openshift/release/blob/master/ci-operator/config/openshift/cluster-api-provider-openstack/openshift-cluster-api-provider-openstack-master.yaml
and
https://github.com/openshift/ocp-build-data/blob/openshift-4.6/images/ose-openstack-machine-controllers.yml
should be updated with the new dockerfile path.

**Which issue(s) this PR fixes**
Bugzilla 1872080
