### PR TITLE
BUG 1858400: [Performance] Increase leader elect retry period to 90s

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -37,7 +37,7 @@ import (
 var (
 	leaseDuration = 120 * time.Second
 	renewDeadline = 110 * time.Second
-	retryPeriod   = 20 * time.Second
+	retryPeriod   = 90 * time.Second
 )
 
 func main() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This change increases the leader election retry period to 90s. This
change is being made to reduce the number of updates that can occur to
etcd in a worst case leader election scenario.

This was supposed to be part of #114 , but got missed due to a copy-paste error.

**Which issue(s) this PR fixes** 
Bugzilla 1858400