### PR TITLE
make primary subnet a programatic part of provider spec

### DIFF
--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -91,6 +91,9 @@ type OpenstackProviderSpec struct {
 	// ServerGroupName are non-empty, they must refer to the same OpenStack
 	// resource.
 	ServerGroupName string `json:"serverGroupName,omitempty"`
+
+	// The subnet that a set of machines will get ingress/egress traffic from
+	PrimarySubnet string `json:"primarySubnet,omitempty"`
 }
 
 type SecurityGroupParam struct {


### PR DESCRIPTION
Instead of using tags on the subnet, we want the user to be able to have control over the primary subnet in a more standardized way. We are moving the functionality to the provider spec. In most use cases, this will be set automatically by the installer, however, this gives the user the ability to manually override it based on their use case.

/cc @mandre 
