### PR TITLE
Drop openssh from the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,5 @@ COPY . .
 RUN go build -o ./machine-controller-manager ./cmd/manager
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-RUN INSTALL_PKGS=" \
-      openssh \
-      " && \
-    yum install -y $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
-    yum clean all
 
 COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-openstack/machine-controller-manager /


### PR DESCRIPTION
We don't need openssh in the image so there is no reason to keep it.