### PR TITLE
images: Remove openssh from the RHEL variant

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -5,11 +5,5 @@ COPY . .
 RUN go build -o ./machine-controller-manager ./cmd/manager
 
 FROM registry.ci.openshift.org/ocp/4.7:base
-RUN INSTALL_PKGS=" \
-      openssh \
-      " && \
-    yum install -y $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
-    yum clean all
 
 COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-openstack/machine-controller-manager /


### PR DESCRIPTION
openssh is not expected to be useful in the production image.