### PR TITLE
machine/actuator: remove ipv6 restriction

### DIFF
--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -124,7 +124,7 @@ type SecurityGroupFilter struct {
 type NetworkParam struct {
 	// The UUID of the network. Required if you omit the port attribute.
 	UUID string `json:"uuid,omitempty"`
-	// A fixed IPv4 address for the NIC.
+	// A fixed IP address for the NIC.
 	FixedIp string `json:"fixedIp,omitempty"`
 	// Filters for optional network query
 	Filter Filter `json:"filter,omitempty"`

--- a/pkg/cloud/openstack/machine/actuator.go
+++ b/pkg/cloud/openstack/machine/actuator.go
@@ -424,6 +424,11 @@ func getIPsFromInstance(instance *clients.Instance) (map[string]string, error) {
 			"": instance.AccessIPv4,
 		}, nil
 	}
+	if instance.AccessIPv6 != "" && net.ParseIP(instance.AccessIPv6) != nil {
+		return map[string]string{
+			"": instance.AccessIPv6,
+		}, nil
+	}
 	type networkInterface struct {
 		Address string  `json:"addr"`
 		Version float64 `json:"version"`
@@ -442,9 +447,7 @@ func getIPsFromInstance(instance *clients.Instance) (map[string]string, error) {
 			var netInterface networkInterface
 			b, _ := json.Marshal(network)
 			json.Unmarshal(b, &netInterface)
-			if netInterface.Version == 4.0 {
-				addrMap[networkName] = netInterface.Address
-			}
+			addrMap[networkName] = netInterface.Address
 		}
 	}
 	if len(addrMap) == 0 {


### PR DESCRIPTION
Remove the legacy restrictions that was in the machine actuator which
would force to fetch for IPv4 addresses. Let's open it for IPv6 as well.
