### PR TITLE
Bug 1913736: do not fetch image id when booting from volume

### DIFF
--- a/pkg/cloud/openstack/clients/machineservice.go
+++ b/pkg/cloud/openstack/clients/machineservice.go
@@ -551,9 +551,13 @@ func (is *InstanceService) InstanceCreate(clusterName string, name string, clust
 		is.computeClient.Microversion = "2.52"
 	}
 
-	imageID, err := imageutils.IDFromName(is.imagesClient, config.Image)
-	if err != nil {
-		return nil, fmt.Errorf("Create new server err: %v", err)
+	var imageID string
+
+	if config.RootVolume == nil {
+		imageID, err = imageutils.IDFromName(is.imagesClient, config.Image)
+		if err != nil {
+			return nil, fmt.Errorf("Create new server err: %v", err)
+		}
 	}
 
 	flavorID, err := flavorutils.IDFromName(is.computeClient, config.Flavor)

--- a/pkg/cloud/openstack/machine/actuator.go
+++ b/pkg/cloud/openstack/machine/actuator.go
@@ -699,10 +699,12 @@ func (oc *OpenstackClient) validateMachine(machine *machinev1.Machine) error {
 
 	// TODO(mfedosin): add more validations here
 
-	// Validate that image exists
-	err = machineService.DoesImageExist(machineSpec.Image)
-	if err != nil {
-		return err
+	// Validate that image exists when not booting from volume
+	if machineSpec.RootVolume == nil {
+		err = machineService.DoesImageExist(machineSpec.Image)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Validate that flavor exists


### PR DESCRIPTION
When we boot a machine from volume, we don't need to fetch the image id.