### PR TITLE
Remove pkg/errors dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/openshift/api v0.0.0-20201019163320-c6a5ec25f267
 	github.com/openshift/client-go v0.0.0-20201020074620-f8fd44879f7c
 	github.com/openshift/machine-api-operator v0.2.1-0.20201203125141-79567cb3368e
-	github.com/pkg/errors v0.9.1
 	github.com/vincent-petithory/dataurl v0.0.0-20160330182126-9a301d65acbb // indirect
 	go4.org v0.0.0-20191010144846-132d2879e1e9 // indirect
 	gopkg.in/yaml.v2 v2.3.0

--- a/pkg/cloud/openstack/machineset/controller.go
+++ b/pkg/cloud/openstack/machineset/controller.go
@@ -6,7 +6,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -133,7 +132,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrlRuntime.Manager, options controlle
 	// see https://sdk.operatorframework.io/docs/building-operators/golang/tutorial/#controller-configurations
 
 	if err != nil {
-		return errors.Wrap(err, "controller creation failed")
+		return fmt.Errorf("controller creation failed: %w", err)
 	}
 
 	r.Client = mgr.GetClient()
@@ -144,7 +143,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrlRuntime.Manager, options controlle
 	config := mgr.GetConfig()
 	r.kubeClient, err = kubernetes.NewForConfig(config)
 	if err != nil {
-		return errors.Wrap(err, "could not create kubernetes client to talk to the API server")
+		return fmt.Errorf("could not create kubernetes client to talk to the API server: %w", err)
 	}
 	r.flavorCache = newMachineFlavorCache()
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -240,7 +240,6 @@ github.com/openshift/machine-api-operator/pkg/util
 # github.com/peterbourgon/diskv v2.0.1+incompatible
 github.com/peterbourgon/diskv
 # github.com/pkg/errors v0.9.1
-## explicit
 github.com/pkg/errors
 # github.com/prometheus/client_golang v1.7.1
 github.com/prometheus/client_golang/prometheus


### PR DESCRIPTION
Use the new fmt.Errorf "%w" verb instead.

/hold Can wait until 4.8 master is open.