### PR TITLE
Update BZ component

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,5 +4,5 @@ approvers:
   - shiftstack-team
 reviewers:
   - shiftstack-team
-component: "Installer"
-subcomponent: "OpenShift on OpenStack"
+component: "Cloud Compute"
+subcomponent: "OpenStack Provider"


### PR DESCRIPTION
Bug reported against CAPO should be filled under `Cloud Compute ->
OpenStack Provider`.