### PR TITLE
Tag Ports Created By CAPO Based on Network or Subnet Attached

### DIFF
--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -132,6 +132,8 @@ type NetworkParam struct {
 	Subnets []SubnetParam `json:"subnets,omitempty"`
 	// NoAllowedAddressPairs disables creation of allowed address pairs for the network ports
 	NoAllowedAddressPairs bool `json:"noAllowedAddressPairs,omitempty"`
+	// PortTags allows users to specify a list of tags to add to ports created in a given network
+	PortTags []string `json:"portTags,omitempty"`
 }
 
 type Filter struct {
@@ -159,6 +161,9 @@ type SubnetParam struct {
 
 	// Filters for optional network query
 	Filter SubnetFilter `json:"filter,omitempty"`
+
+	// PortTags are tags that are added to ports created on this subnet
+	PortTags []string `json:"portTags,omitempty"`
 }
 
 type SubnetFilter struct {

--- a/pkg/cloud/openstack/clients/machineservice_test.go
+++ b/pkg/cloud/openstack/clients/machineservice_test.go
@@ -27,3 +27,37 @@ func TestMachineServiceInstance(t *testing.T) {
 		t.Errorf("Couldn't create instance service: %v", err)
 	}
 }
+
+func TestDeduplicateLists(t *testing.T) {
+	list1 := []string{"1", "2", "3", "a", "b", "c"}
+	list2 := []string{"1", "c"}
+
+	// Case 1: Lists with no duplicates has same elements
+	result := deduplicateList(list1)
+	if !equal(result, list1) {
+		t.Errorf("List with no duplicates should contain the same elements. \n\tExpected:%v\n\tGot:%v", list1, result)
+	}
+
+	// Case 2: Lists with duplicates have coppies of elements removed
+	dupe1 := append(list1, list2...)
+	result = deduplicateList(dupe1)
+	if !equal(list1, result) {
+		t.Errorf("List with duplicates should have coppies of elements removed.\n\tExpected:%v\n\tGot:%v", list1, result)
+	}
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	m := map[string]bool{}
+	for _, v := range a {
+		m[v] = true
+	}
+	for _, v := range b {
+		if _, ok := m[v]; !ok {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Gives users the ability to tag the ports CAPO creates based on the network or subnet they are attached to. Some Usage patterns in the ProviderSpec are as follows:

```yaml
...
tags:
  - tag1
Networks:
  - uuid: ****-****-****-net1
    portTags:
      - tag2
    subnets:
      - uuid: ****-****-****-snet1
        portTags: 
          - tag3
      - uuid: ****-****-****-snet2
        portTags: 
          - tag4
```
tag1: all resources created by CAPO
tag2: all ports attached to network net1 created by CAPO
tag3: all ports attached to subnet snet1 created by CAPO
tag4: all ports attached to subnet snet2 created by CAPO

Fixes: [OSASINFRA-2348](https://issues.redhat.com/browse/OSASINFRA-2348)