### PR TITLE
Adds vnictype to port creation

### DIFF
--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -134,6 +134,7 @@ type NetworkParam struct {
 	NoAllowedAddressPairs bool `json:"noAllowedAddressPairs,omitempty"`
 	// PortTags allows users to specify a list of tags to add to ports created in a given network
 	PortTags []string `json:"portTags,omitempty"`
+	VNICType string   `json:"vnicType,omitempty"`
 }
 
 type Filter struct {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsbinding/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsbinding/doc.go
@@ -1,0 +1,3 @@
+// Package portsbinding provides information and interaction with the port
+// binding extension for the OpenStack Networking service.
+package portsbinding

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsbinding/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsbinding/requests.go
@@ -1,0 +1,96 @@
+package portsbinding
+
+import (
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
+)
+
+// CreateOptsExt adds port binding options to the base ports.CreateOpts.
+type CreateOptsExt struct {
+	// CreateOptsBuilder is the interface options structs have to satisfy in order
+	// to be used in the main Create operation in this package.
+	ports.CreateOptsBuilder
+
+	// The ID of the host where the port is allocated
+	HostID string `json:"binding:host_id,omitempty"`
+
+	// The virtual network interface card (vNIC) type that is bound to the
+	// neutron port.
+	VNICType string `json:"binding:vnic_type,omitempty"`
+
+	// A dictionary that enables the application running on the specified
+	// host to pass and receive virtual network interface (VIF) port-specific
+	// information to the plug-in.
+	Profile map[string]interface{} `json:"binding:profile,omitempty"`
+}
+
+// ToPortCreateMap casts a CreateOpts struct to a map.
+func (opts CreateOptsExt) ToPortCreateMap() (map[string]interface{}, error) {
+	base, err := opts.CreateOptsBuilder.ToPortCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	port := base["port"].(map[string]interface{})
+
+	if opts.HostID != "" {
+		port["binding:host_id"] = opts.HostID
+	}
+
+	if opts.VNICType != "" {
+		port["binding:vnic_type"] = opts.VNICType
+	}
+
+	if opts.Profile != nil {
+		port["binding:profile"] = opts.Profile
+	}
+
+	return base, nil
+}
+
+// UpdateOptsExt adds port binding options to the base ports.UpdateOpts
+type UpdateOptsExt struct {
+	// UpdateOptsBuilder is the interface options structs have to satisfy in order
+	// to be used in the main Update operation in this package.
+	ports.UpdateOptsBuilder
+
+	// The ID of the host where the port is allocated.
+	HostID *string `json:"binding:host_id,omitempty"`
+
+	// The virtual network interface card (vNIC) type that is bound to the
+	// neutron port.
+	VNICType string `json:"binding:vnic_type,omitempty"`
+
+	// A dictionary that enables the application running on the specified
+	// host to pass and receive virtual network interface (VIF) port-specific
+	// information to the plug-in.
+	Profile map[string]interface{} `json:"binding:profile,omitempty"`
+}
+
+// ToPortUpdateMap casts an UpdateOpts struct to a map.
+func (opts UpdateOptsExt) ToPortUpdateMap() (map[string]interface{}, error) {
+	base, err := opts.UpdateOptsBuilder.ToPortUpdateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	port := base["port"].(map[string]interface{})
+
+	if opts.HostID != nil {
+		port["binding:host_id"] = *opts.HostID
+	}
+
+	if opts.VNICType != "" {
+		port["binding:vnic_type"] = opts.VNICType
+	}
+
+	if opts.Profile != nil {
+		if len(opts.Profile) == 0 {
+			// send null instead of the empty json object ("{}")
+			port["binding:profile"] = nil
+		} else {
+			port["binding:profile"] = opts.Profile
+		}
+	}
+
+	return base, nil
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsbinding/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsbinding/results.go
@@ -1,0 +1,24 @@
+package portsbinding
+
+// PortsBindingExt represents a decorated form of a Port with the additional
+// port binding information.
+type PortsBindingExt struct {
+	// The ID of the host where the port is allocated.
+	HostID string `json:"binding:host_id"`
+
+	// A dictionary that enables the application to pass information about
+	// functions that the Networking API provides.
+	VIFDetails map[string]interface{} `json:"binding:vif_details"`
+
+	// The VIF type for the port.
+	VIFType string `json:"binding:vif_type"`
+
+	// The virtual network interface card (vNIC) type that is bound to the
+	// neutron port.
+	VNICType string `json:"binding:vnic_type"`
+
+	// A dictionary that enables the application running on the specified
+	// host to pass and receive virtual network interface (VIF) port-specific
+	// information to the plug-in.
+	Profile map[string]interface{} `json:"binding:profile"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -122,6 +122,7 @@ github.com/gophercloud/gophercloud/openstack/imageservice/v2/images
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers
+github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsbinding
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks


### PR DESCRIPTION
Adding the vnicType to the network definition allows for the user to select the type of openstack network port that will be createdc. 



https://issues.redhat.com/browse/OSASINFRA-2335