### PR TITLE
Port Count

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ COPY . .
 
 RUN go build -o ./machine-controller-manager ./cmd/manager
 
-FROM registry.ci.openshift.org/openshift/origin-v4.7:base
+FROM registry.ci.openshift.org/origin/4.8:base
 
 COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-openstack/machine-controller-manager /

--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -134,7 +134,14 @@ type NetworkParam struct {
 	NoAllowedAddressPairs bool `json:"noAllowedAddressPairs,omitempty"`
 	// PortTags allows users to specify a list of tags to add to ports created in a given network
 	PortTags []string `json:"portTags,omitempty"`
-	VNICType string   `json:"vnicType,omitempty"`
+	// VNICTYpe specifies the nic type of the ports created on this network
+	// Default: "Normal"
+	// +optional
+	VNICType string `json:"vnicType,omitempty"`
+	// PortCount is a positive, non-zero, intiger representing the number of ports in this network to attach to each node
+	// Default: 1
+	// +optional
+	PortCount uint `json:"portCount,omitempty"`
 }
 
 type Filter struct {
@@ -165,6 +172,11 @@ type SubnetParam struct {
 
 	// PortTags are tags that are added to ports created on this subnet
 	PortTags []string `json:"portTags,omitempty"`
+
+	// PortCount is a positive, non-zero, intiger representing the number of ports in this subnet to attach to each node
+	// Default: 1
+	// +optional
+	PortCount uint `json:"portCount,omitempty"`
 }
 
 type SubnetFilter struct {

--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -142,6 +142,9 @@ type NetworkParam struct {
 	// Default: 1
 	// +optional
 	PortCount uint `json:"portCount,omitempty"`
+	// PortSecurity is a boolean value that indicates whether security is enabled on ports created for this subnet
+	// Default: Nova default
+	PortSecurity *bool `json:"portSecurity,omitempty"`
 }
 
 type Filter struct {
@@ -177,6 +180,10 @@ type SubnetParam struct {
 	// Default: 1
 	// +optional
 	PortCount uint `json:"portCount,omitempty"`
+
+	// PortSecurity is a boolean value that indicates whether security is enabled on ports created for this subnet
+	// Default: Nova default
+	PortSecurity *bool `json:"portSecurity,omitempty"`
 }
 
 type SubnetFilter struct {

--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -134,16 +134,17 @@ type NetworkParam struct {
 	NoAllowedAddressPairs bool `json:"noAllowedAddressPairs,omitempty"`
 	// PortTags allows users to specify a list of tags to add to ports created in a given network
 	PortTags []string `json:"portTags,omitempty"`
-	// VNICTYpe specifies the nic type of the ports created on this network
-	// Default: "Normal"
+	// VNICType specifies the nic type of the ports created on this network
+	// Default: nova default
 	// +optional
 	VNICType string `json:"vnicType,omitempty"`
-	// PortCount is a positive, non-zero, intiger representing the number of ports in this network to attach to each node
+	// PortCount is a positive, non-zero, integer representing the number of ports in this network to attach to each node
 	// Default: 1
 	// +optional
 	PortCount uint `json:"portCount,omitempty"`
 	// PortSecurity is a boolean value that indicates whether security is enabled on ports created for this subnet
 	// Default: Nova default
+	// +optional
 	PortSecurity *bool `json:"portSecurity,omitempty"`
 }
 
@@ -183,6 +184,7 @@ type SubnetParam struct {
 
 	// PortSecurity is a boolean value that indicates whether security is enabled on ports created for this subnet
 	// Default: Nova default
+	// +optional
 	PortSecurity *bool `json:"portSecurity,omitempty"`
 }
 

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity/doc.go
@@ -1,0 +1,145 @@
+/*
+Package portsecurity provides information and interaction with the port
+security extension for the OpenStack Networking service.
+
+Example to List Networks with Port Security Information
+
+	type NetworkWithPortSecurityExt struct {
+		networks.Network
+		portsecurity.PortSecurityExt
+	}
+
+	var allNetworks []NetworkWithPortSecurityExt
+
+	listOpts := networks.ListOpts{
+		Name: "network_1",
+	}
+
+	allPages, err := networks.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	err = networks.ExtractNetworksInto(allPages, &allNetworks)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, network := range allNetworks {
+		fmt.Println("%+v\n", network)
+	}
+
+Example to Create a Network without Port Security
+
+	var networkWithPortSecurityExt struct {
+		networks.Network
+		portsecurity.PortSecurityExt
+	}
+
+	networkCreateOpts := networks.CreateOpts{
+		Name: "private",
+	}
+
+	iFalse := false
+	createOpts := portsecurity.NetworkCreateOptsExt{
+		CreateOptsBuilder:   networkCreateOpts,
+		PortSecurityEnabled: &iFalse,
+	}
+
+	err := networks.Create(networkClient, createOpts).ExtractInto(&networkWithPortSecurityExt)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("%+v\n", networkWithPortSecurityExt)
+
+Example to Disable Port Security on an Existing Network
+
+	var networkWithPortSecurityExt struct {
+		networks.Network
+		portsecurity.PortSecurityExt
+	}
+
+	iFalse := false
+	networkID := "4e8e5957-649f-477b-9e5b-f1f75b21c03c"
+	networkUpdateOpts := networks.UpdateOpts{}
+	updateOpts := portsecurity.NetworkUpdateOptsExt{
+		UpdateOptsBuilder:   networkUpdateOpts,
+		PortSecurityEnabled: &iFalse,
+	}
+
+	err := networks.Update(networkClient, networkID, updateOpts).ExtractInto(&networkWithPortSecurityExt)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("%+v\n", networkWithPortSecurityExt)
+
+Example to Get a Port with Port Security Information
+
+	var portWithPortSecurityExtensions struct {
+		ports.Port
+		portsecurity.PortSecurityExt
+	}
+
+	portID := "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2"
+
+	err := ports.Get(networkingClient, portID).ExtractInto(&portWithPortSecurityExtensions)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("%+v\n", portWithPortSecurityExtensions)
+
+Example to Create a Port Without Port Security
+
+	var portWithPortSecurityExtensions struct {
+		ports.Port
+		portsecurity.PortSecurityExt
+	}
+
+	iFalse := false
+	networkID := "4e8e5957-649f-477b-9e5b-f1f75b21c03c"
+	subnetID := "a87cc70a-3e15-4acf-8205-9b711a3531b7"
+
+	portCreateOpts := ports.CreateOpts{
+		NetworkID: networkID,
+		FixedIPs:  []ports.IP{ports.IP{SubnetID: subnetID}},
+	}
+
+	createOpts := portsecurity.PortCreateOptsExt{
+		CreateOptsBuilder:   portCreateOpts,
+		PortSecurityEnabled: &iFalse,
+	}
+
+	err := ports.Create(networkingClient, createOpts).ExtractInto(&portWithPortSecurityExtensions)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("%+v\n", portWithPortSecurityExtensions)
+
+Example to Disable Port Security on an Existing Port
+
+	var portWithPortSecurityExtensions struct {
+		ports.Port
+		portsecurity.PortSecurityExt
+	}
+
+	iFalse := false
+	portID := "65c0ee9f-d634-4522-8954-51021b570b0d"
+
+	portUpdateOpts := ports.UpdateOpts{}
+	updateOpts := portsecurity.PortUpdateOptsExt{
+		UpdateOptsBuilder:   portUpdateOpts,
+		PortSecurityEnabled: &iFalse,
+	}
+
+	err := ports.Update(networkingClient, portID, updateOpts).ExtractInto(&portWithPortSecurityExtensions)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("%+v\n", portWithPortSecurityExtensions)
+*/
+package portsecurity

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity/requests.go
@@ -1,0 +1,104 @@
+package portsecurity
+
+import (
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
+)
+
+// PortCreateOptsExt adds port security options to the base ports.CreateOpts.
+type PortCreateOptsExt struct {
+	ports.CreateOptsBuilder
+
+	// PortSecurityEnabled toggles port security on a port.
+	PortSecurityEnabled *bool `json:"port_security_enabled,omitempty"`
+}
+
+// ToPortCreateMap casts a CreateOpts struct to a map.
+func (opts PortCreateOptsExt) ToPortCreateMap() (map[string]interface{}, error) {
+	base, err := opts.CreateOptsBuilder.ToPortCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	port := base["port"].(map[string]interface{})
+
+	if opts.PortSecurityEnabled != nil {
+		port["port_security_enabled"] = &opts.PortSecurityEnabled
+	}
+
+	return base, nil
+}
+
+// PortUpdateOptsExt adds port security options to the base ports.UpdateOpts.
+type PortUpdateOptsExt struct {
+	ports.UpdateOptsBuilder
+
+	// PortSecurityEnabled toggles port security on a port.
+	PortSecurityEnabled *bool `json:"port_security_enabled,omitempty"`
+}
+
+// ToPortUpdateMap casts a UpdateOpts struct to a map.
+func (opts PortUpdateOptsExt) ToPortUpdateMap() (map[string]interface{}, error) {
+	base, err := opts.UpdateOptsBuilder.ToPortUpdateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	port := base["port"].(map[string]interface{})
+
+	if opts.PortSecurityEnabled != nil {
+		port["port_security_enabled"] = &opts.PortSecurityEnabled
+	}
+
+	return base, nil
+}
+
+// NetworkCreateOptsExt adds port security options to the base
+// networks.CreateOpts.
+type NetworkCreateOptsExt struct {
+	networks.CreateOptsBuilder
+
+	// PortSecurityEnabled toggles port security on a port.
+	PortSecurityEnabled *bool `json:"port_security_enabled,omitempty"`
+}
+
+// ToNetworkCreateMap casts a CreateOpts struct to a map.
+func (opts NetworkCreateOptsExt) ToNetworkCreateMap() (map[string]interface{}, error) {
+	base, err := opts.CreateOptsBuilder.ToNetworkCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	network := base["network"].(map[string]interface{})
+
+	if opts.PortSecurityEnabled != nil {
+		network["port_security_enabled"] = &opts.PortSecurityEnabled
+	}
+
+	return base, nil
+}
+
+// NetworkUpdateOptsExt adds port security options to the base
+// networks.UpdateOpts.
+type NetworkUpdateOptsExt struct {
+	networks.UpdateOptsBuilder
+
+	// PortSecurityEnabled toggles port security on a port.
+	PortSecurityEnabled *bool `json:"port_security_enabled,omitempty"`
+}
+
+// ToNetworkUpdateMap casts a UpdateOpts struct to a map.
+func (opts NetworkUpdateOptsExt) ToNetworkUpdateMap() (map[string]interface{}, error) {
+	base, err := opts.UpdateOptsBuilder.ToNetworkUpdateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	network := base["network"].(map[string]interface{})
+
+	if opts.PortSecurityEnabled != nil {
+		network["port_security_enabled"] = &opts.PortSecurityEnabled
+	}
+
+	return base, nil
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity/results.go
@@ -1,0 +1,7 @@
+package portsecurity
+
+type PortSecurityExt struct {
+	// PortSecurityEnabled specifies whether port security is enabled or
+	// disabled.
+	PortSecurityEnabled bool `json:"port_security_enabled"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -123,6 +123,7 @@ github.com/gophercloud/gophercloud/openstack/networking/v2/extensions
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsbinding
+github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks


### PR DESCRIPTION
Allows you to specify how many ports to attach to each machine created for a given network.
This patch also includes some fixes to how ports are attached to nodes:
- ensures no duplicate ports
- ensures ports are not taken
- ensures ports meet networking needs specified by user

Fixes: [OSASINFRA-2364](https://issues.redhat.com/browse/OSASINFRA-2364)