### PR TITLE
Bug 1747270: InstanceService.GetInstanceList should not do substring search on name

### DIFF
--- a/pkg/cloud/openstack/clients/machineservice.go
+++ b/pkg/cloud/openstack/clients/machineservice.go
@@ -885,7 +885,9 @@ func (is *InstanceService) GetInstanceList(opts *InstanceListOpts) ([]*Instance,
 	var listOpts servers.ListOpts
 	if opts != nil {
 		listOpts = servers.ListOpts{
-			Name: opts.Name,
+			// Name is a regular expression, so we need to explicitly specify a
+			// whole string match. https://bugzilla.redhat.com/show_bug.cgi?id=1747270
+			Name: fmt.Sprintf("^%s$", opts.Name),
 		}
 	} else {
 		listOpts = servers.ListOpts{}


### PR DESCRIPTION
The server list api defines the name parameter to be a regular
expression:

https://docs.openstack.org/api-ref/compute/?expanded=list-servers-detail#list-servers

This meant that the usage of it in InstanceService.GetInstanceList was a
substring lookup rather than the intended lookup by name.

Fixes: rhbz1747270

```release-note
NONE
```
