### PR TITLE
Ports NetworkID json typo

### DIFF
--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -200,7 +200,7 @@ type SubnetFilter struct {
 }
 
 type PortOpts struct {
-	NetworkID           string              `json:"networkId" required:"true"`
+	NetworkID           string              `json:"networkID" required:"true"`
 	NameSuffix          string              `json:"nameSuffix" required:"true"`
 	Description         string              `json:"description,omitempty"`
 	AdminStateUp        *bool               `json:"adminStateUp,omitempty"`


### PR DESCRIPTION
The json argument is `networkId` when the standard naming scheme for
fields ending in ID dictates that it should be named `networkID`.

