### PR TITLE
Bug 1948546: Port create bugs

### DIFF
--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -206,8 +206,6 @@ type PortOpts struct {
 	AdminStateUp        *bool               `json:"adminStateUp,omitempty"`
 	MACAddress          string              `json:"macAddress,omitempty"`
 	FixedIPs            []ports.IP          `json:"fixedIPs,omitempty"`
-	DeviceID            string              `json:"deviceID,omitempty"`
-	DeviceOwner         string              `json:"deviceOwner,omitempty"`
 	TenantID            string              `json:"tenantID,omitempty"`
 	ProjectID           string              `json:"projectID,omitempty"`
 	SecurityGroups      *[]string           `json:"securityGroups,omitempty"`

--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -205,7 +205,7 @@ type PortOpts struct {
 	Description         string              `json:"description,omitempty"`
 	AdminStateUp        *bool               `json:"adminStateUp,omitempty"`
 	MACAddress          string              `json:"macAddress,omitempty"`
-	FixedIPs            []ports.IP          `json:"fixedIPs,omitempty"`
+	FixedIPs            []FixedIPs          `json:"fixedIPs,omitempty"`
 	TenantID            string              `json:"tenantID,omitempty"`
 	ProjectID           string              `json:"projectID,omitempty"`
 	SecurityGroups      *[]string           `json:"securityGroups,omitempty"`
@@ -213,15 +213,20 @@ type PortOpts struct {
 	Tags                []string            `json:"tags,omitempty"`
 
 	// The ID of the host where the port is allocated
-	HostID string `json:"binding:hostID,omitempty"`
+	HostID string `json:"hostID,omitempty"`
 
 	// The virtual network interface card (vNIC) type that is bound to the
 	// neutron port.
-	VNICType string `json:"binding:vnicType,omitempty"`
+	VNICType string `json:"vnicType,omitempty"`
 
 	// enable or disable security on a given port
 	// incompatible with securityGroups and allowedAddressPairs
 	PortSecurity *bool `json:"portSecurity,omitempty"`
+}
+
+type FixedIPs struct {
+	SubnetID  string `json:"subnetID"`
+	IPAddress string `json:"ipAddress,omitempty"`
 }
 
 type RootVolume struct {

--- a/pkg/cloud/openstack/clients/machineservice.go
+++ b/pkg/cloud/openstack/clients/machineservice.go
@@ -345,7 +345,12 @@ func getOrCreatePort(is *InstanceService, name string, portOpts openstackconfigv
 			AllowedAddressPairs: portOpts.AllowedAddressPairs,
 		}
 		if len(portOpts.FixedIPs) != 0 {
-			createOpts.FixedIPs = portOpts.FixedIPs
+			fixedIPs := make([]ports.IP, len(portOpts.FixedIPs))
+			for i, portOptIP := range portOpts.FixedIPs {
+				fixedIPs[i].SubnetID = portOptIP.SubnetID
+				fixedIPs[i].IPAddress = portOptIP.IPAddress
+			}
+			createOpts.FixedIPs = fixedIPs
 		}
 		newPort, err := ports.Create(is.networkClient, portsbinding.CreateOptsExt{
 			CreateOptsBuilder: createOpts,
@@ -510,7 +515,7 @@ func (is *InstanceService) InstanceCreate(clusterName string, name string, clust
 				for _, snet := range snetResults {
 					nets = append(nets, openstackconfigv1.PortOpts{
 						NetworkID:    snet.NetworkID,
-						FixedIPs:     []ports.IP{{SubnetID: snet.ID}},
+						FixedIPs:     []openstackconfigv1.FixedIPs{{SubnetID: snet.ID}},
 						Tags:         append(net.PortTags, snetParam.PortTags...),
 						VNICType:     net.VNICType,
 						PortSecurity: portSecurity,

--- a/pkg/cloud/openstack/clients/machineservice.go
+++ b/pkg/cloud/openstack/clients/machineservice.go
@@ -357,9 +357,14 @@ func getOrCreatePort(is *InstanceService, name string, portOpts openstackconfigv
 			return nil, err
 		}
 
-		if portOpts.PortSecurity != nil && *portOpts.PortSecurity == false {
+		if portOpts.PortSecurity != nil {
+			portUpdateOpts := ports.UpdateOpts{}
+			if *portOpts.PortSecurity == false {
+				portUpdateOpts.SecurityGroups = &[]string{}
+				portUpdateOpts.AllowedAddressPairs = &[]ports.AddressPair{}
+			}
 			updateOpts := portsecurity.PortUpdateOptsExt{
-				UpdateOptsBuilder:   ports.UpdateOpts{},
+				UpdateOptsBuilder:   portUpdateOpts,
 				PortSecurityEnabled: portOpts.PortSecurity,
 			}
 			err = ports.Update(is.networkClient, newPort.ID, updateOpts).ExtractInto(&portWithPortSecurityExtensions)
@@ -546,10 +551,6 @@ func (is *InstanceService) InstanceCreate(clusterName string, name string, clust
 		}
 		portOpt.SecurityGroups = &securityGroups
 		portOpt.AllowedAddressPairs = allowedAddressPairs
-		if portOpt.PortSecurity != nil && *portOpt.PortSecurity == false {
-			portOpt.SecurityGroups = &[]string{}
-			portOpt.AllowedAddressPairs = []ports.AddressPair{}
-		}
 		if _, ok := netsWithoutAllowedAddressPairs[portOpt.NetworkID]; ok {
 			portOpt.AllowedAddressPairs = []ports.AddressPair{}
 		}

--- a/pkg/cloud/openstack/clients/machineservice.go
+++ b/pkg/cloud/openstack/clients/machineservice.go
@@ -339,8 +339,6 @@ func getOrCreatePort(is *InstanceService, name string, portOpts openstackconfigv
 			Description:         portOpts.Description,
 			AdminStateUp:        portOpts.AdminStateUp,
 			MACAddress:          portOpts.MACAddress,
-			DeviceID:            portOpts.DeviceID,
-			DeviceOwner:         portOpts.DeviceOwner,
 			TenantID:            portOpts.TenantID,
 			ProjectID:           portOpts.ProjectID,
 			SecurityGroups:      portOpts.SecurityGroups,


### PR DESCRIPTION
There were a number of issues in the way we allowed users to create ports/interfaces for nodes through the machine API. This patch looks to clean them up to prevent race conditions or OpenStack errors that could cause a deployment to fail due to logical errors in cluster-api-provider-openstack. 
