### PR TITLE
[WIP] Bug 1942686: Extend trunk configuration to port level in machineset

### DIFF
--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -222,6 +222,9 @@ type PortOpts struct {
 	// enable or disable security on a given port
 	// incompatible with securityGroups and allowedAddressPairs
 	PortSecurity *bool `json:"portSecurity,omitempty"`
+
+	// Port is to be part of a trunk
+	Trunk               bool               `json:"trunnk,omitempty"`
 }
 
 type FixedIPs struct {


### PR DESCRIPTION
With the introduction of new technologies, like SR-IOV,
it is required that the user have the ability to
configure trunked and not-trunked ports for the same machines.

