### PR TITLE
[WIP] Bug 1936511 Do not override net uuid if subnet uuid is defined.

### DIFF
--- a/pkg/cloud/openstack/clients/machineservice.go
+++ b/pkg/cloud/openstack/clients/machineservice.go
@@ -499,7 +499,9 @@ func (is *InstanceService) InstanceCreate(clusterName string, name string, clust
 
 			for _, snetParam := range net.Subnets {
 				sopts := subnets.ListOpts(snetParam.Filter)
-				sopts.ID = snetParam.UUID
+				if snetParam.UUID == "" {
+					sopts.ID = snetParam.UUID
+				}
 				sopts.NetworkID = netID
 				// Inherit portSecurity from network if unset on subnet
 				portSecurity := net.PortSecurity


### PR DESCRIPTION
If the user provides a subnet UUID under the networks filter,
we should not override the net uuid of the subnet because
by property of the subnet having UUID it means it already has
been created, which means that here already is an immutable link
between the subnet and _a_ network
Overriding the value of the net uuid in the subnet definition  at that point
can result in an invalid query, because
the current code allows for listing network UUIDs and subnet UUIDs under
the same entry of providerSpec.Networks which do not belong together.

The resulting lookup can end up in returning a port to be created which
cannot be created by OpenStack.
A port to be attached to a subnet that does not belong to the network
listed.

This patch give preference to the subnet associated with the subnet.UUID

