### PR TITLE
Bug 1952179: Port Allowed Address Pairs UI

### DIFF
--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -200,17 +199,17 @@ type SubnetFilter struct {
 }
 
 type PortOpts struct {
-	NetworkID           string              `json:"networkID" required:"true"`
-	NameSuffix          string              `json:"nameSuffix" required:"true"`
-	Description         string              `json:"description,omitempty"`
-	AdminStateUp        *bool               `json:"adminStateUp,omitempty"`
-	MACAddress          string              `json:"macAddress,omitempty"`
-	FixedIPs            []FixedIPs          `json:"fixedIPs,omitempty"`
-	TenantID            string              `json:"tenantID,omitempty"`
-	ProjectID           string              `json:"projectID,omitempty"`
-	SecurityGroups      *[]string           `json:"securityGroups,omitempty"`
-	AllowedAddressPairs []ports.AddressPair `json:"allowedAddressPairs,omitempty"`
-	Tags                []string            `json:"tags,omitempty"`
+	NetworkID           string        `json:"networkID" required:"true"`
+	NameSuffix          string        `json:"nameSuffix" required:"true"`
+	Description         string        `json:"description,omitempty"`
+	AdminStateUp        *bool         `json:"adminStateUp,omitempty"`
+	MACAddress          string        `json:"macAddress,omitempty"`
+	FixedIPs            []FixedIPs    `json:"fixedIPs,omitempty"`
+	TenantID            string        `json:"tenantID,omitempty"`
+	ProjectID           string        `json:"projectID,omitempty"`
+	SecurityGroups      *[]string     `json:"securityGroups,omitempty"`
+	AllowedAddressPairs []AddressPair `json:"allowedAddressPairs,omitempty"`
+	Tags                []string      `json:"tags,omitempty"`
 
 	// The ID of the host where the port is allocated
 	HostID string `json:"hostID,omitempty"`
@@ -222,6 +221,11 @@ type PortOpts struct {
 	// enable or disable security on a given port
 	// incompatible with securityGroups and allowedAddressPairs
 	PortSecurity *bool `json:"portSecurity,omitempty"`
+}
+
+type AddressPair struct {
+	IPAddress  string `json:"ipAddress,omitempty"`
+	MACAddress string `json:"macAddress,omitempty"`
 }
 
 type FixedIPs struct {


### PR DESCRIPTION
The allowed Address pairs were using the gohpercloud ports.allowed
address pairs struct. This prevents us from being in control of the api,
and may lead to unexpected updates. This also causes the names in the
api to be underscored instead of camel case, which is inconsistent.