### PR TITLE
Bug 1948546: Allow all networking interfaces to be defined as ports

### DIFF
--- a/pkg/cloud/openstack/clients/machineservice.go
+++ b/pkg/cloud/openstack/clients/machineservice.go
@@ -531,9 +531,6 @@ func (is *InstanceService) InstanceCreate(clusterName string, name string, clust
 			}
 		}
 	}
-	if len(nets) == 0 {
-		return nil, fmt.Errorf("No network was found or provided. Please check your machine configuration and try again")
-	}
 
 	clusterInfra, err := configClient.Infrastructures().Get(context.TODO(), "cluster", metav1.GetOptions{})
 	if err != nil {
@@ -559,7 +556,7 @@ func (is *InstanceService) InstanceCreate(clusterName string, name string, clust
 	var portsList []servers.Network
 	for _, portOpt := range nets {
 		if portOpt.NetworkID == "" {
-			return nil, fmt.Errorf("No network was found or provided. Please check your machine configuration and try again")
+			return nil, fmt.Errorf("A network was not found or provided for one of the networks or subnets in this machineset")
 		}
 		portOpt.SecurityGroups = &securityGroups
 		portOpt.AllowedAddressPairs = allowedAddressPairs
@@ -634,6 +631,10 @@ func (is *InstanceService) InstanceCreate(clusterName string, name string, clust
 		portsList = append(portsList, servers.Network{
 			Port: port.ID,
 		})
+	}
+
+	if len(portsList) == 0 {
+		return nil, fmt.Errorf("At least one network, subnet, or port must be defined as a networking interface. Please review your machineset and try again")
 	}
 
 	var serverTags []string


### PR DESCRIPTION
Rather than require users to use the networks and subnets to define a
networking interface for an instance, users should be able to just
define them using the ports api if they choose to. This removes
validation checking that a user entered at least one network and subnet,
and insteand checks that a user entered at least one network, subnet, or
port.

Fixes Bug 1948546:
The correct way to configure the OpenStack provider spec in a machineset with interfaces on networks with port security disabled is now as follows in the example below. This is because it is impossible to attach networks with port security enabled when a security group is set on the instance. It will fail with: `Network requires port_security_enabled and subnet associated in order to apply security groups.`

```yaml
      providerSpec:
        value:
          apiVersion: openstackproviderconfig.openshift.io/v1alpha1
          cloudName: openstack
          cloudsSecret:
            name: openstack-cloud-credentials
            namespace: openshift-machine-api
          flavor: ci.m1.xlarge
          image: rhcos-4.8
          kind: OpenstackProviderSpec
          metadata:
            creationTimestamp: null
          ports:
          - allowedAddressPairs:       # node port to communicate with cluster on machine subnet
            - ipAddress: 10.0.128.7    # ingress vip port
            - ipAddress: 10.0.128.5    # api vip port
            fixedIPs:
            - subnetID: eba0e7cc-b4df-426d-ba97-16fc770cd202
            nameSuffix: nodes
            networkID: ff5ac995-84b3-4494-ab2d-2eb3accf7f15
            securityGroups:            # attach the workers security group here
            - 1f8e583d-3f80-49f6-8628-de081e26d8fb
          - fixedIPs:                  # example port on network without port security
            - subnetID: 55028db4-8979-4f18-a38c-6074c2965c08
            nameSuffix: noPortSecurity
            networkID: bf01893c-2a9c-4695-b8c1-c43129e5efdd
          primarySubnet: eba0e7cc-b4df-426d-ba97-16fc770cd202  # must set this when attaching more than one port
          serverMetadata:
            Name: emilio-ggfm6-worker
            openshiftClusterID: emilio-ggfm6
          tags:
          - openshiftClusterID=emilio-ggfm6
          trunk: false
          userDataSecret:
            name: worker-user-data
```