### PR TITLE
Bug 1983612: Make InstanceCreate idempotent

### DIFF
--- a/pkg/cloud/openstack/clients/utils.go
+++ b/pkg/cloud/openstack/clients/utils.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 
@@ -105,4 +106,27 @@ func GetProviderClient(cloud clientconfig.Cloud, cert []byte) (*gophercloud.Prov
 	}
 
 	return provider, nil
+}
+
+// volumeIDsFromName returns zero or more IDs corresponding to a name. The returned
+// error is only non-nil in case of failure.
+func volumeIDsFromName(client *gophercloud.ServiceClient, name string) ([]string, error) {
+	pages, err := volumes.List(client, volumes.ListOpts{
+		Name: name,
+	}).AllPages()
+	if err != nil {
+		return nil, err
+	}
+
+	all, err := volumes.ExtractVolumes(pages)
+	if err != nil {
+		return nil, err
+	}
+
+	IDs := make([]string, len(all))
+	for i := range all {
+		IDs[i] = all[i].ID
+	}
+
+	return IDs, nil
 }


### PR DESCRIPTION
Prior to this change, if machine-controller gets reprovisioned in the
middle of running InstanceCreate, stale volumes might be left on the
cluster.

With this change, before creating a new root volume for an instance,
InstanceCreate deletes any volumes with the same name.
