### PR TITLE
Bug 1996155: UPSTREAM: 964: getOrCreatePort: add support to configure port Profile

### DIFF
--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -135,8 +135,9 @@ type NetworkParam struct {
 	// NoAllowedAddressPairs disables creation of allowed address pairs for the network ports
 	NoAllowedAddressPairs bool `json:"noAllowedAddressPairs,omitempty"`
 	// PortTags allows users to specify a list of tags to add to ports created in a given network
-	PortTags []string `json:"portTags,omitempty"`
-	VNICType string   `json:"vnicType,omitempty"`
+	PortTags []string          `json:"portTags,omitempty"`
+	VNICType string            `json:"vnicType,omitempty"`
+	Profile  map[string]string `json:"profile,omitempty"`
 	// PortSecurity optionally enables or disables security on ports managed by OpenStack
 	PortSecurity *bool `json:"portSecurity,omitempty"`
 }
@@ -217,6 +218,11 @@ type PortOpts struct {
 	// The virtual network interface card (vNIC) type that is bound to the
 	// neutron port.
 	VNICType string `json:"vnicType,omitempty"`
+
+	// A dictionary that enables the application running on the specified
+	// host to pass and receive virtual network interface (VIF) port-specific
+	// information to the plug-in.
+	Profile map[string]string `json:"profile,omitempty"`
 
 	// enable or disable security on a given port
 	// incompatible with securityGroups and allowedAddressPairs


### PR DESCRIPTION
Upstream: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/964

Configuring port profiles can be useful to enable an application
running on the specified host to pass and receive VIF port-specific
information to the plugin.

One of the use-cases here is when configuring ports in OVS Hardware
offload, where we need to use the profile:
{"capabilities": ["switchdev"]}

Thanks to this patch, we'll now able to do it when creating the
machines and their ports.

[OSASINFRA-2434](https://issues.redhat.com/browse/OSASINFRA-2434)
