### PR TITLE
Bug 1986540: Adds Proxy to provider client http transport

### DIFF
--- a/pkg/cloud/openstack/clients/utils.go
+++ b/pkg/cloud/openstack/clients/utils.go
@@ -92,6 +92,7 @@ func GetProviderClient(cloud clientconfig.Cloud, cert []byte) (*gophercloud.Prov
 				TLSClientConfig: &tls.Config{
 					RootCAs: certPool,
 				},
+				Proxy: http.ProxyFromEnvironment,
 			},
 		}
 		provider.HTTPClient = client


### PR DESCRIPTION
Enables machine-controller to use proxy from environment variables injected into the container.