### PR TITLE
getOrCreatePort: add support to configure port QoS

### DIFF
--- a/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -135,9 +135,10 @@ type NetworkParam struct {
 	// NoAllowedAddressPairs disables creation of allowed address pairs for the network ports
 	NoAllowedAddressPairs bool `json:"noAllowedAddressPairs,omitempty"`
 	// PortTags allows users to specify a list of tags to add to ports created in a given network
-	PortTags []string          `json:"portTags,omitempty"`
-	VNICType string            `json:"vnicType,omitempty"`
-	Profile  map[string]string `json:"profile,omitempty"`
+	PortTags    []string          `json:"portTags,omitempty"`
+	VNICType    string            `json:"vnicType,omitempty"`
+	Profile     map[string]string `json:"profile,omitempty"`
+	QoSPolicyID string            `json:"qosPolicyID,omitempty"`
 	// PortSecurity optionally enables or disables security on ports managed by OpenStack
 	PortSecurity *bool `json:"portSecurity,omitempty"`
 }
@@ -223,6 +224,9 @@ type PortOpts struct {
 	// host to pass and receive virtual network interface (VIF) port-specific
 	// information to the plug-in.
 	Profile map[string]string `json:"profile,omitempty"`
+
+	// A string for the QoS policy ID of the network where this port is plugged.
+	QoSPolicyID string `json:"qosPolicyID,omitempty"`
 
 	// enable or disable security on a given port
 	// incompatible with securityGroups and allowedAddressPairs

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies/doc.go
@@ -1,0 +1,257 @@
+/*
+Package policies provides information and interaction with the QoS policy extension
+for the OpenStack Networking service.
+
+Example to Get a Port with a QoS policy
+
+    var portWithQoS struct {
+        ports.Port
+        policies.QoSPolicyExt
+    }
+
+    portID := "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2"
+
+    err = ports.Get(client, portID).ExtractInto(&portWithQoS)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Printf("Port: %+v\n", portWithQoS)
+
+Example to Create a Port with a QoS policy
+
+    var portWithQoS struct {
+        ports.Port
+        policies.QoSPolicyExt
+    }
+
+    policyID := "d6ae28ce-fcb5-4180-aa62-d260a27e09ae"
+    networkID := "7069db8d-e817-4b39-a654-d2dd76e73d36"
+
+    portCreateOpts := ports.CreateOpts{
+        NetworkID: networkID,
+    }
+
+    createOpts := policies.PortCreateOptsExt{
+        CreateOptsBuilder: portCreateOpts,
+        QoSPolicyID:       policyID,
+    }
+
+    err = ports.Create(client, createOpts).ExtractInto(&portWithQoS)
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("Port: %+v\n", portWithQoS)
+
+Example to Add a QoS policy to an existing Port
+
+    var portWithQoS struct {
+        ports.Port
+        policies.QoSPolicyExt
+    }
+
+    portUpdateOpts := ports.UpdateOpts{}
+
+    policyID := "d6ae28ce-fcb5-4180-aa62-d260a27e09ae"
+
+    updateOpts := policies.PortUpdateOptsExt{
+        UpdateOptsBuilder: portUpdateOpts,
+        QoSPolicyID:       &policyID,
+    }
+
+    err := ports.Update(client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&portWithQoS)
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("Port: %+v\n", portWithQoS)
+
+Example to Delete a QoS policy from the existing Port
+
+    var portWithQoS struct {
+        ports.Port
+        policies.QoSPolicyExt
+    }
+
+    portUpdateOpts := ports.UpdateOpts{}
+
+    policyID := ""
+
+    updateOpts := policies.PortUpdateOptsExt{
+        UpdateOptsBuilder: portUpdateOpts,
+        QoSPolicyID:       &policyID,
+    }
+
+    err := ports.Update(client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&portWithQoS)
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("Port: %+v\n", portWithQoS)
+
+Example to Get a Network with a QoS policy
+
+    var networkWithQoS struct {
+        networks.Network
+        policies.QoSPolicyExt
+    }
+
+    networkID := "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2"
+
+    err = networks.Get(client, networkID).ExtractInto(&networkWithQoS)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Printf("Network: %+v\n", networkWithQoS)
+
+Example to Create a Network with a QoS policy
+
+    var networkWithQoS struct {
+        networks.Network
+        policies.QoSPolicyExt
+    }
+
+    policyID := "d6ae28ce-fcb5-4180-aa62-d260a27e09ae"
+    networkID := "7069db8d-e817-4b39-a654-d2dd76e73d36"
+
+    networkCreateOpts := networks.CreateOpts{
+        NetworkID: networkID,
+    }
+
+    createOpts := policies.NetworkCreateOptsExt{
+        CreateOptsBuilder: networkCreateOpts,
+        QoSPolicyID:       policyID,
+    }
+
+    err = networks.Create(client, createOpts).ExtractInto(&networkWithQoS)
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("Network: %+v\n", networkWithQoS)
+
+Example to add a QoS policy to an existing Network
+
+    var networkWithQoS struct {
+        networks.Network
+        policies.QoSPolicyExt
+    }
+
+    networkUpdateOpts := networks.UpdateOpts{}
+
+    policyID := "d6ae28ce-fcb5-4180-aa62-d260a27e09ae"
+
+    updateOpts := policies.NetworkUpdateOptsExt{
+        UpdateOptsBuilder: networkUpdateOpts,
+        QoSPolicyID:       &policyID,
+    }
+
+    err := networks.Update(client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&networkWithQoS)
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("Network: %+v\n", networkWithQoS)
+
+Example to delete a QoS policy from the existing Network
+
+    var networkWithQoS struct {
+        networks.Network
+        policies.QoSPolicyExt
+    }
+
+    networkUpdateOpts := networks.UpdateOpts{}
+
+    policyID := ""
+
+    updateOpts := policies.NetworkUpdateOptsExt{
+        UpdateOptsBuilder: networkUpdateOpts,
+        QoSPolicyID:       &policyID,
+    }
+
+    err := networks.Update(client, "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&networkWithQoS)
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("Network: %+v\n", networkWithQoS)
+
+Example to List QoS policies
+
+    shared := true
+    listOpts := policies.ListOpts{
+        Name:   "shared-policy",
+        Shared: &shared,
+    }
+
+    allPages, err := policies.List(networkClient, listOpts).AllPages()
+    if err != nil {
+        panic(err)
+    }
+
+	allPolicies, err := policies.ExtractPolicies(allPages)
+    if err != nil {
+        panic(err)
+    }
+
+    for _, policy := range allPolicies {
+        fmt.Printf("%+v\n", policy)
+    }
+
+Example to Get a specific QoS policy
+
+    policyID := "30a57f4a-336b-4382-8275-d708babd2241"
+
+    policy, err := policies.Get(networkClient, policyID).Extract()
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("%+v\n", policy)
+
+Example to Create a QoS policy
+
+    createOpts := policies.CreateOpts{
+        Name:      "shared-default-policy",
+        Shared:    true,
+        IsDefault: true,
+    }
+
+    policy, err := policies.Create(networkClient, createOpts).Extract()
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("%+v\n", policy)
+
+Example to Update a QoS policy
+
+    shared := true
+    isDefault := false
+    opts := policies.UpdateOpts{
+        Name:      "new-name",
+        Shared:    &shared,
+        IsDefault: &isDefault,
+    }
+
+    policyID := "30a57f4a-336b-4382-8275-d708babd2241"
+
+    policy, err := policies.Update(networkClient, policyID, opts).Extract()
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("%+v\n", policy)
+
+Example to Delete a QoS policy
+
+    policyID := "30a57f4a-336b-4382-8275-d708babd2241"
+
+    err := policies.Delete(networkClient, policyID).ExtractErr()
+    if err != nil {
+        panic(err)
+    }
+*/
+package policies

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies/requests.go
@@ -1,0 +1,271 @@
+package policies
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// PortCreateOptsExt adds QoS options to the base ports.CreateOpts.
+type PortCreateOptsExt struct {
+	ports.CreateOptsBuilder
+
+	// QoSPolicyID represents an associated QoS policy.
+	QoSPolicyID string `json:"qos_policy_id,omitempty"`
+}
+
+// ToPortCreateMap casts a CreateOpts struct to a map.
+func (opts PortCreateOptsExt) ToPortCreateMap() (map[string]interface{}, error) {
+	base, err := opts.CreateOptsBuilder.ToPortCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	port := base["port"].(map[string]interface{})
+
+	if opts.QoSPolicyID != "" {
+		port["qos_policy_id"] = opts.QoSPolicyID
+	}
+
+	return base, nil
+}
+
+// PortUpdateOptsExt adds QoS options to the base ports.UpdateOpts.
+type PortUpdateOptsExt struct {
+	ports.UpdateOptsBuilder
+
+	// QoSPolicyID represents an associated QoS policy.
+	// Setting it to a pointer of an empty string will remove associated QoS policy from port.
+	QoSPolicyID *string `json:"qos_policy_id,omitempty"`
+}
+
+// ToPortUpdateMap casts a UpdateOpts struct to a map.
+func (opts PortUpdateOptsExt) ToPortUpdateMap() (map[string]interface{}, error) {
+	base, err := opts.UpdateOptsBuilder.ToPortUpdateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	port := base["port"].(map[string]interface{})
+
+	if opts.QoSPolicyID != nil {
+		qosPolicyID := *opts.QoSPolicyID
+		if qosPolicyID != "" {
+			port["qos_policy_id"] = qosPolicyID
+		} else {
+			port["qos_policy_id"] = nil
+		}
+	}
+
+	return base, nil
+}
+
+// NetworkCreateOptsExt adds QoS options to the base networks.CreateOpts.
+type NetworkCreateOptsExt struct {
+	networks.CreateOptsBuilder
+
+	// QoSPolicyID represents an associated QoS policy.
+	QoSPolicyID string `json:"qos_policy_id,omitempty"`
+}
+
+// ToNetworkCreateMap casts a CreateOpts struct to a map.
+func (opts NetworkCreateOptsExt) ToNetworkCreateMap() (map[string]interface{}, error) {
+	base, err := opts.CreateOptsBuilder.ToNetworkCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	network := base["network"].(map[string]interface{})
+
+	if opts.QoSPolicyID != "" {
+		network["qos_policy_id"] = opts.QoSPolicyID
+	}
+
+	return base, nil
+}
+
+// NetworkUpdateOptsExt adds QoS options to the base networks.UpdateOpts.
+type NetworkUpdateOptsExt struct {
+	networks.UpdateOptsBuilder
+
+	// QoSPolicyID represents an associated QoS policy.
+	// Setting it to a pointer of an empty string will remove associated QoS policy from network.
+	QoSPolicyID *string `json:"qos_policy_id,omitempty"`
+}
+
+// ToNetworkUpdateMap casts a UpdateOpts struct to a map.
+func (opts NetworkUpdateOptsExt) ToNetworkUpdateMap() (map[string]interface{}, error) {
+	base, err := opts.UpdateOptsBuilder.ToNetworkUpdateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	network := base["network"].(map[string]interface{})
+
+	if opts.QoSPolicyID != nil {
+		qosPolicyID := *opts.QoSPolicyID
+		if qosPolicyID != "" {
+			network["qos_policy_id"] = qosPolicyID
+		} else {
+			network["qos_policy_id"] = nil
+		}
+	}
+
+	return base, nil
+}
+
+// PolicyListOptsBuilder allows extensions to add additional parameters to the List request.
+type PolicyListOptsBuilder interface {
+	ToPolicyListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the Neutron API. Filtering is achieved by passing in struct field values
+// that map to the Policy attributes you want to see returned.
+// SortKey allows you to sort by a particular Policy attribute.
+// SortDir sets the direction, and is either `asc' or `desc'.
+// Marker and Limit are used for the pagination.
+type ListOpts struct {
+	ID             string `q:"id"`
+	TenantID       string `q:"tenant_id"`
+	ProjectID      string `q:"project_id"`
+	Name           string `q:"name"`
+	Description    string `q:"description"`
+	RevisionNumber *int   `q:"revision_number"`
+	IsDefault      *bool  `q:"is_default"`
+	Shared         *bool  `q:"shared"`
+	Limit          int    `q:"limit"`
+	Marker         string `q:"marker"`
+	SortKey        string `q:"sort_key"`
+	SortDir        string `q:"sort_dir"`
+	Tags           string `q:"tags"`
+	TagsAny        string `q:"tags-any"`
+	NotTags        string `q:"not-tags"`
+	NotTagsAny     string `q:"not-tags-any"`
+}
+
+// ToPolicyListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToPolicyListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// Policy. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+func List(c *gophercloud.ServiceClient, opts PolicyListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToPolicyListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return PolicyPage{pagination.LinkedPageBase{PageResult: r}}
+
+	})
+}
+
+// Get retrieves a specific QoS policy based on its ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := c.Get(getURL(c, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// CreateOptsBuilder allows to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToPolicyCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts specifies parameters of a new QoS policy.
+type CreateOpts struct {
+	// Name is the human-readable name of the QoS policy.
+	Name string `json:"name"`
+
+	// TenantID is the id of the Identity project.
+	TenantID string `json:"tenant_id,omitempty"`
+
+	// ProjectID is the id of the Identity project.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// Shared indicates whether this QoS policy is shared across all projects.
+	Shared bool `json:"shared,omitempty"`
+
+	// Description is the human-readable description for the QoS policy.
+	Description string `json:"description,omitempty"`
+
+	// IsDefault indicates if this QoS policy is default policy or not.
+	IsDefault bool `json:"is_default,omitempty"`
+}
+
+// ToPolicyCreateMap constructs a request body from CreateOpts.
+func (opts CreateOpts) ToPolicyCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "policy")
+}
+
+// Create requests the creation of a new QoS policy on the server.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToPolicyCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToPolicyUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts represents options used to update a QoS policy.
+type UpdateOpts struct {
+	// Name is the human-readable name of the QoS policy.
+	Name string `json:"name,omitempty"`
+
+	// Shared indicates whether this QoS policy is shared across all projects.
+	Shared *bool `json:"shared,omitempty"`
+
+	// Description is the human-readable description for the QoS policy.
+	Description *string `json:"description,omitempty"`
+
+	// IsDefault indicates if this QoS policy is default policy or not.
+	IsDefault *bool `json:"is_default,omitempty"`
+}
+
+// ToPolicyUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToPolicyUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "policy")
+}
+
+// Update accepts a UpdateOpts struct and updates an existing policy using the
+// values provided.
+func Update(c *gophercloud.ServiceClient, policyID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToPolicyUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Put(updateURL(c, policyID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Delete accepts a unique ID and deletes the QoS policy associated with it.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	resp, err := c.Delete(deleteURL(c, id), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies/results.go
@@ -1,0 +1,127 @@
+package policies
+
+import (
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// QoSPolicyExt represents additional resource attributes available with the QoS extension.
+type QoSPolicyExt struct {
+	// QoSPolicyID represents an associated QoS policy.
+	QoSPolicyID string `json:"qos_policy_id"`
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a QoS policy.
+type GetResult struct {
+	commonResult
+}
+
+// CreateResult represents the result of a Create operation. Call its Extract
+// method to interpret it as a QoS policy.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of a Create operation. Call its Extract
+// method to interpret it as a QoS policy.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// Extract is a function that accepts a result and extracts a QoS policy resource.
+func (r commonResult) Extract() (*Policy, error) {
+	var s struct {
+		Policy *Policy `json:"policy"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Policy, err
+}
+
+// Policy represents a QoS policy.
+type Policy struct {
+	// ID is the id of the policy.
+	ID string `json:"id"`
+
+	// Name is the human-readable name of the policy.
+	Name string `json:"name"`
+
+	// TenantID is the id of the Identity project.
+	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the id of the Identity project.
+	ProjectID string `json:"project_id"`
+
+	// CreatedAt is the time at which the policy has been created.
+	CreatedAt time.Time `json:"created_at"`
+
+	// UpdatedAt is the time at which the policy has been created.
+	UpdatedAt time.Time `json:"updated_at"`
+
+	// IsDefault indicates if the policy is default policy or not.
+	IsDefault bool `json:"is_default"`
+
+	// Description is thehuman-readable description for the resource.
+	Description string `json:"description"`
+
+	// Shared indicates whether this policy is shared across all projects.
+	Shared bool `json:"shared"`
+
+	// RevisionNumber represents revision number of the policy.
+	RevisionNumber int `json:"revision_number"`
+
+	// Rules represents QoS rules of the policy.
+	Rules []map[string]interface{} `json:"rules"`
+
+	// Tags optionally set via extensions/attributestags
+	Tags []string `json:"tags"`
+}
+
+// PolicyPage stores a single page of Policies from a List() API call.
+type PolicyPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of policies has reached
+// the end of a page and the pager seeks to traverse over a new one.
+// In order to do this, it needs to construct the next page's URL.
+func (r PolicyPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"policies_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a PolicyPage is empty.
+func (r PolicyPage) IsEmpty() (bool, error) {
+	is, err := ExtractPolicies(r)
+	return len(is) == 0, err
+}
+
+// ExtractPolicies accepts a PolicyPage, and extracts the elements into a slice of Policies.
+func ExtractPolicies(r pagination.Page) ([]Policy, error) {
+	var s []Policy
+	err := ExtractPolicysInto(r, &s)
+	return s, err
+}
+
+// ExtractPoliciesInto extracts the elements into a slice of RBAC Policy structs.
+func ExtractPolicysInto(r pagination.Page, v interface{}) error {
+	return r.(PolicyPage).Result.ExtractIntoSlicePtr(v, "policies")
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies/urls.go
@@ -1,0 +1,33 @@
+package policies
+
+import "github.com/gophercloud/gophercloud"
+
+const resourcePath = "qos/policies"
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(resourcePath)
+}
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(resourcePath, id)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -117,6 +117,7 @@ github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributes
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsbinding
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity
+github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/qos/policies
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks


### PR DESCRIPTION
Configuring QoS Policy ID on ports can be useful to apply Quality of
Services into the OpenStack Neutron ports, for example in NFV use-cases.

[OSASINFRA-2447](https://issues.redhat.com/browse/OSASINFRA-2447)
