### PR TITLE
Bug 2033862: Ensure subnets belong to the queried network

### DIFF
--- a/pkg/cloud/openstack/clients/machineservice.go
+++ b/pkg/cloud/openstack/clients/machineservice.go
@@ -608,6 +608,11 @@ func (is *InstanceService) InstanceCreate(clusterName string, name string, clust
 					return nil, err
 				}
 				for _, snet := range snetResults {
+					// Under some circumstances the filter ignores the NetworkID
+					// See https://bugzilla.redhat.com/show_bug.cgi?id=2033862
+					if snet.NetworkID != netID {
+						continue
+					}
 					nets = append(nets, openstackconfigv1.PortOpts{
 						NetworkID:    snet.NetworkID,
 						NameSuffix:   snet.ID,


### PR DESCRIPTION
There is a known issue with Cisco ACI [1] that causes the query to
return subnets that don't belong to the specified network. We can
workaround it and ensure the subnets really belong to the network.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2027305