### PR TITLE
Add target to run e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,3 +153,7 @@ dist: build-cross
 
 .PHONY: build clean cover docs fmt lint realclean \
 	relnotes test translation version build-cross dist unit
+
+.PHONY: test-e2e
+test-e2e: ## Run e2e tests
+	hack/e2e.sh

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+unset GOFLAGS
+tmp="$(mktemp -d)"
+
+git clone "https://github.com/openshift/cluster-api-actuator-pkg.git" "$tmp"
+
+exec make -C "$tmp" test-e2e


### PR DESCRIPTION
This commit adds e2e test to Makefile.  This test
will clone cluster-api-actuator-pkg and run tests
from that clone.

Copied from GCP's provider [1].

[1] https://github.com/openshift/machine-api-provider-gcp/commit/492fd64f713f51a89a317d75649bf5181e6292ba