### PR TITLE
Bug 1921656: Remove dependence on annotation to allow Server deletion

### DIFF
--- a/pkg/cloud/openstack/machine/actuator.go
+++ b/pkg/cloud/openstack/machine/actuator.go
@@ -303,8 +303,7 @@ func (oc *OpenstackClient) Delete(ctx context.Context, machine *machinev1.Machin
 		return nil
 	}
 
-	id := machine.ObjectMeta.Annotations[OpenstackIdAnnotationKey]
-	err = machineService.InstanceDelete(id)
+	err = machineService.InstanceDelete(instance.ID)
 	if err != nil {
 		return oc.handleMachineError(machine, apierrors.DeleteMachine(
 			"error deleting Openstack instance: %v", err), deleteEventAction)


### PR DESCRIPTION
If a failure happened while handling the Machine creation,
the Machine can end up without an openstack-resourceId
annotation. This makes the deletion of the Machine to fail as
no Server ID was specified in the annotation. This commit fixes
the issue by making the deletion rely on the Server ID retrieved
prior to delete instead of using the annotation.

Co-authored-by: Matthew Booth mbooth@redhat.com


**Release note**:
```release-note
NONE
```
