### PR TITLE
Add support to IPv6 in Machine's status

### DIFF
--- a/pkg/cloud/services/compute/instance_types.go
+++ b/pkg/cloud/services/compute/instance_types.go
@@ -152,15 +152,9 @@ func (is *InstanceStatus) NetworkStatus() (*InstanceNetworkStatus, error) {
 			return nil, fmt.Errorf("error unmarshalling addresses for instance %s: %w", is.ID(), err)
 		}
 
-		var addresses []corev1.NodeAddress
+		var IPv4addresses, IPv6addresses []corev1.NodeAddress
 		for i := range interfaceList {
 			address := &interfaceList[i]
-
-			// Only consider IPv4
-			if address.Version != 4 {
-				is.logger.V(6).Info("Ignoring IP address: only IPv4 is supported", "version", address.Version, "address", address.Address)
-				continue
-			}
 
 			var addressType corev1.NodeAddressType
 			switch address.Type {
@@ -172,14 +166,20 @@ func (is *InstanceStatus) NetworkStatus() (*InstanceNetworkStatus, error) {
 				is.logger.V(6).Info("Ignoring address with unknown type", "address", address.Address, "type", address.Type)
 				continue
 			}
-
-			addresses = append(addresses, corev1.NodeAddress{
-				Type:    addressType,
-				Address: address.Address,
-			})
+			if address.Version == 4 {
+				IPv4addresses = append(IPv4addresses, corev1.NodeAddress{
+					Type:    addressType,
+					Address: address.Address,
+				})
+			} else {
+				IPv6addresses = append(IPv6addresses, corev1.NodeAddress{
+					Type:    addressType,
+					Address: address.Address,
+				})
+			}
 		}
-
-		addressesByNetwork[networkName] = addresses
+		// Maintain IPv4 addresses being first ones on Machine's status given there are operations, e.g. reconcile load-balancer member, that use the first address by network type
+		addressesByNetwork[networkName] = append(IPv4addresses, IPv6addresses...)
 	}
 
 	return &InstanceNetworkStatus{addressesByNetwork}, nil

--- a/pkg/cloud/services/compute/instance_types_test.go
+++ b/pkg/cloud/services/compute/instance_types_test.go
@@ -107,7 +107,7 @@ func TestNetworkStatus_Addresses(t *testing.T) {
 			},
 		},
 		{
-			name: "Ignore IPv6",
+			name: "Multiple Fixed IP and Floating IP",
 			addresses: map[string][]networkAddress{
 				"primary": {
 					{
@@ -132,6 +132,14 @@ func TestNetworkStatus_Addresses(t *testing.T) {
 				{
 					Type:    corev1.NodeInternalIP,
 					Address: "192.168.0.1",
+				},
+				{
+					Type:    corev1.NodeInternalIP,
+					Address: "fe80::f816:3eff:fe56:3174",
+				},
+				{
+					Type:    corev1.NodeExternalIP,
+					Address: "fe80::f816:3eff:fe56:3175",
 				},
 			},
 		},
@@ -248,7 +256,7 @@ func TestInstanceNetworkStatus(t *testing.T) {
 			wantFloatingIP: "10.0.0.1",
 		},
 		{
-			name: "Ignore IPv6",
+			name: "Multiple Fixed IP and Floating IP",
 			addresses: map[string][]networkAddress{
 				"primary": {
 					{


### PR DESCRIPTION
Dual-stack clusters require that the Machine's status contains the IPv6 address. This commit removed the check that would skip the addition of IPv6 to the Machines. Also, it ensures the IPv4 addresses of each Network remains being the first ones listed in the Machines given there are operations that rely on the first address of each network.

Cherry-pick of https://github.com/kubernetes-sigs/cluster-api-provider-openstack/commit/5926f47ecc7307d617e0efd1148a52969bbbca0d
