### PR TITLE
CARRY: Mark CAPO as second level operator

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -40,3 +40,5 @@ COPY --from=builder /workspace/manager .
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies
 USER 65532
 ENTRYPOINT ["/manager"]
+
+LABEL io.openshift.release.operator true


### PR DESCRIPTION
This is required for it to be included in the release payload. CAPO is actually deployed by cluster-capi-operator, but is not directly referenced by cluster-capi-operator. cluster-capi-operator instead consumes a ConfigMap deployed by CAPO. CAPO must be included in the release payload in order for cluster-capi-operator to be able to consume this ConfigMap.

/hold
