### PR TITLE
CARRY: Add DOWNSTREAM_OWNERS

### DIFF
--- a/DOWNSTREAM_OWNERS
+++ b/DOWNSTREAM_OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - shiftstack-team
+reviewers:
+  - shiftstack-team
+component: "Cloud Compute"
+subcomponent: "OpenStack Provider"

--- a/DOWNSTREAM_OWNERS_ALIASES
+++ b/DOWNSTREAM_OWNERS_ALIASES
@@ -1,0 +1,10 @@
+aliases:
+  shiftstack-team:
+    - EmilienM
+    - MaysaMacedo
+    - dulek
+    - gryf
+    - mandre
+    - mdbooth
+    - pierreprinetti
+    - stephenfin


### PR DESCRIPTION
This will allow us to remove the carry and avoid merge conflicts on upstream OWNERS.

/hold
