### PR TITLE
CARRY: Restore OWNERS to upstream

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,21 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
 approvers:
-  - shiftstack-team
+  - sig-cluster-lifecycle-leads
+  - cluster-api-openstack-maintainers
+
 reviewers:
-  - shiftstack-team
-component: "Cloud Compute"
-subcomponent: "OpenStack Provider"
+  - cluster-api-openstack-maintainers
+  - cluster-api-openstack-reviewers
+
+emeritus_approvers:
+  - ncdc
+  - chaosaffe
+  - chrigl
+  - dims
+  - gyliu513
+  - Lion-Wei
+  - m1093782566
+  - sbueringer
+  - hidekazuna
+  - chrischdi

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,10 +1,28 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+#
+# When making changes to this file, also consider if you need to update:
+# - https://github.com/kubernetes/org/blob/main/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+# - https://github.com/kubernetes/test-infra/blob/master/OWNERS_ALIASES
+# - https://github.com/kubernetes/k8s.io/blob/main/groups/sig-architecture/groups.yaml
+# - https://github.com/kubernetes/k8s.io/blob/main/groups/sig-cluster-lifecycle/groups.yaml
+
 aliases:
-  shiftstack-team:
-    - EmilienM
-    - MaysaMacedo
-    - dulek
-    - gryf
-    - mandre
+  # sig-cluster-lifecycle-leads are included as approvers in case it's ever
+  # operationally expedient:
+  # Source:
+  # https://github.com/kubernetes/org/blob/main/config/kubernetes/sig-cluster-lifecycle/teams.yaml
+  # correct as of 2023/05/10
+  sig-cluster-lifecycle-leads:
+    - CecileRobertMichon
+    - fabriziopandini
+    - justinsb
+    - neolit123
+    - vincepri
+  cluster-api-openstack-maintainers:
+    - jichenjc
+    - lentzi90
     - mdbooth
-    - pierreprinetti
-    - stephenfin
+    - seanschneeweiss
+    - tobiasgiese
+  cluster-api-openstack-reviewers:
+    - dulek


### PR DESCRIPTION
We are now using DOWNSTREAM_OWNERS instead. We can restore OWNERS and OWNERS_ALIASES to upstream to avoid future merge conflicts.

TODO:
- [x] https://github.com/openshift/release/pull/44167

/hold