### PR TITLE
🐛 openshift: Fix label of cluster-capi infrastructure CM

### DIFF
--- a/openshift/kustomize/cluster-capi-configmap/kustomization.yaml
+++ b/openshift/kustomize/cluster-capi-configmap/kustomization.yaml
@@ -9,7 +9,7 @@ components:
 generatorOptions:
   disableNameSuffixHash: true
   labels:
-    provider.cluster.x-k8s.io/name: cluster-api-provider-openstack
+    provider.cluster.x-k8s.io/name: openstack
     provider.cluster.x-k8s.io/type: infrastructure
     provider.cluster.x-k8s.io/version: v0.8.0
 

--- a/openshift/manifests/0000_30_cluster-api-provider-openstack_04_infrastructure-components.yaml
+++ b/openshift/manifests/0000_30_cluster-api-provider-openstack_04_infrastructure-components.yaml
@@ -10729,7 +10729,7 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
-    provider.cluster.x-k8s.io/name: cluster-api-provider-openstack
+    provider.cluster.x-k8s.io/name: openstack
     provider.cluster.x-k8s.io/type: infrastructure
     provider.cluster.x-k8s.io/version: v0.8.0
   name: openstack


### PR DESCRIPTION
Incorrect label prevents deployment by cluster-capi-operator.

/hold
