### PR TITLE
Fix syntax in .skyk

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -3,5 +3,5 @@
 # https://docs.snyk.io/snyk-cli/commands/ignore
 exclude:
   global:
-    - vendor/**
-    - **/vendor/**
+    - "vendor/**"
+    - "**/vendor/**"

--- a/.snyk
+++ b/.snyk
@@ -5,3 +5,6 @@ exclude:
   global:
     - "vendor/**"
     - "**/vendor/**"
+    - "hack/**"
+    - "test/**"
+    - "**/*_test.go"


### PR DESCRIPTION
This previously caused the job to fail with:

     ✗ [High] the referenced anchor is not defined: */vendor/**
       ID: 62e8960c-5e98-4900-b60c-b67ea2a03767
       Path: .snyk, line 7
       Info: the referenced anchor is not defined: */vendor/**