### PR TITLE
NO-ISSUE: CARRY: openshift/manifests: Drop single-node-developer profile

### DIFF
--- a/openshift/kustomize/components/common/kustomization.yaml
+++ b/openshift/kustomize/components/common/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
 commonAnnotations:
   exclude.release.openshift.io/internal-openshift-hosted: "true"
   include.release.openshift.io/self-managed-high-availability: "true"
-  include.release.openshift.io/single-node-developer: "true"
 
 patches:
 # Common configuration for CAPI controller workloads

--- a/openshift/manifests/0000_30_cluster-api-provider-openstack_00_credentials-request.yaml
+++ b/openshift/manifests/0000_30_cluster-api-provider-openstack_00_credentials-request.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: openshift-cluster-api-openstack
   namespace: openshift-cloud-credential-operator

--- a/openshift/manifests/0000_30_cluster-api-provider-openstack_04_infrastructure-components.yaml
+++ b/openshift/manifests/0000_30_cluster-api-provider-openstack_04_infrastructure-components.yaml
@@ -8,7 +8,6 @@ data:
         controller-gen.kubebuilder.io/version: v0.13.0
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
         service.beta.openshift.io/inject-cabundle: "true"
       labels:
@@ -4724,7 +4723,6 @@ data:
         controller-gen.kubebuilder.io/version: v0.13.0
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
         service.beta.openshift.io/inject-cabundle: "true"
       labels:
@@ -6977,7 +6975,6 @@ data:
         controller-gen.kubebuilder.io/version: v0.13.0
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
         service.beta.openshift.io/inject-cabundle: "true"
       labels:
@@ -8610,7 +8607,6 @@ data:
         controller-gen.kubebuilder.io/version: v0.13.0
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
         service.beta.openshift.io/inject-cabundle: "true"
       labels:
@@ -9965,7 +9961,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -9978,7 +9973,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -9991,7 +9985,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10033,7 +10026,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10085,7 +10077,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10107,7 +10098,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10151,7 +10141,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10241,7 +10230,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10262,7 +10250,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10283,7 +10270,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10304,7 +10290,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10325,7 +10310,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10345,7 +10329,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10365,7 +10348,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
         service.beta.openshift.io/serving-cert-secret-name: capo-webhook-service-cert
       labels:
@@ -10385,7 +10367,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10403,7 +10384,6 @@ data:
           annotations:
             exclude.release.openshift.io/internal-openshift-hosted: "true"
             include.release.openshift.io/self-managed-high-availability: "true"
-            include.release.openshift.io/single-node-developer: "true"
             release.openshift.io/feature-set: TechPreviewNoUpgrade
             target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
           labels:
@@ -10475,7 +10455,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10493,7 +10472,6 @@ data:
           annotations:
             exclude.release.openshift.io/internal-openshift-hosted: "true"
             include.release.openshift.io/self-managed-high-availability: "true"
-            include.release.openshift.io/single-node-developer: "true"
             release.openshift.io/feature-set: TechPreviewNoUpgrade
             target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
           labels:
@@ -10553,7 +10531,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
         service.beta.openshift.io/inject-cabundle: "true"
       labels:
@@ -10630,7 +10607,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
         service.beta.openshift.io/inject-cabundle: "true"
       labels:
@@ -10726,7 +10702,6 @@ metadata:
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
     provider.cluster.x-k8s.io/name: openstack


### PR DESCRIPTION
As in openshift/cluster-version-operator@48fe9f2669 (openshift/cluster-version-operator#685).

There's [an enhancement proposal for this profile][1], and the Code Ready Containers folks [took a run at using it][2] before [backing off][3].  I don't have any problems with having a specific CRC profile, but if we end up going that way, we'll need a lot more manifests with the annotation (e.g. we'll probably also want the CVO manifests to include this annotation, or there won't be anything consuming the admin-ack ConfigMaps ;).  This commit drops the annotation from this repository to avoid distracting folks with dead code.

[1]: https://github.com/openshift/enhancements/blob/2911c46bf7d2f22eb1ab81739b4f9c2603fd0c07/enhancements/single-node/developer-cluster-profile.md
[2]: https://github.com/crc-org/snc/pull/338
[3]: https://github.com/crc-org/snc/pull/373#issue-835807822