### PR TITLE
OCPBUGS-26027: openshift/manifests: CloudCredential capability for CredentialsRequest

### DIFF
--- a/openshift/kustomize/components/common/kustomization.yaml
+++ b/openshift/kustomize/components/common/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
 commonAnnotations:
   exclude.release.openshift.io/internal-openshift-hosted: "true"
   include.release.openshift.io/self-managed-high-availability: "true"
-  include.release.openshift.io/single-node-developer: "true"
 
 patches:
 # Common configuration for CAPI controller workloads

--- a/openshift/kustomize/credentials-request/credentials-request.yaml
+++ b/openshift/kustomize/credentials-request/credentials-request.yaml
@@ -3,6 +3,8 @@ kind: CredentialsRequest
 metadata:
   name: openshift-cluster-api-openstack
   namespace: openshift-cloud-credential-operator
+  annotations:
+    capability.openshift.io/name: CloudCredential
 spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1

--- a/openshift/manifests/0000_30_cluster-api-provider-openstack_00_credentials-request.yaml
+++ b/openshift/manifests/0000_30_cluster-api-provider-openstack_00_credentials-request.yaml
@@ -2,6 +2,7 @@ apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest
 metadata:
   annotations:
+    capability.openshift.io/name: CloudCredential
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/openshift/manifests/0000_30_cluster-api-provider-openstack_00_credentials-request.yaml
+++ b/openshift/manifests/0000_30_cluster-api-provider-openstack_00_credentials-request.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: openshift-cluster-api-openstack
   namespace: openshift-cloud-credential-operator

--- a/openshift/manifests/0000_30_cluster-api-provider-openstack_04_infrastructure-components.yaml
+++ b/openshift/manifests/0000_30_cluster-api-provider-openstack_04_infrastructure-components.yaml
@@ -8,7 +8,6 @@ data:
         controller-gen.kubebuilder.io/version: v0.13.0
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
         service.beta.openshift.io/inject-cabundle: "true"
       labels:
@@ -4724,7 +4723,6 @@ data:
         controller-gen.kubebuilder.io/version: v0.13.0
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
         service.beta.openshift.io/inject-cabundle: "true"
       labels:
@@ -6977,7 +6975,6 @@ data:
         controller-gen.kubebuilder.io/version: v0.13.0
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
         service.beta.openshift.io/inject-cabundle: "true"
       labels:
@@ -8610,7 +8607,6 @@ data:
         controller-gen.kubebuilder.io/version: v0.13.0
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
         service.beta.openshift.io/inject-cabundle: "true"
       labels:
@@ -9965,7 +9961,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -9978,7 +9973,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -9991,7 +9985,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10033,7 +10026,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10085,7 +10077,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10107,7 +10098,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10151,7 +10141,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10241,7 +10230,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10262,7 +10250,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10283,7 +10270,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10304,7 +10290,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10325,7 +10310,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10345,7 +10329,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10365,7 +10348,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
         service.beta.openshift.io/serving-cert-secret-name: capo-webhook-service-cert
       labels:
@@ -10385,7 +10367,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10403,7 +10384,6 @@ data:
           annotations:
             exclude.release.openshift.io/internal-openshift-hosted: "true"
             include.release.openshift.io/self-managed-high-availability: "true"
-            include.release.openshift.io/single-node-developer: "true"
             release.openshift.io/feature-set: TechPreviewNoUpgrade
             target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
           labels:
@@ -10475,7 +10455,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -10493,7 +10472,6 @@ data:
           annotations:
             exclude.release.openshift.io/internal-openshift-hosted: "true"
             include.release.openshift.io/self-managed-high-availability: "true"
-            include.release.openshift.io/single-node-developer: "true"
             release.openshift.io/feature-set: TechPreviewNoUpgrade
             target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
           labels:
@@ -10553,7 +10531,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
         service.beta.openshift.io/inject-cabundle: "true"
       labels:
@@ -10630,7 +10607,6 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
         service.beta.openshift.io/inject-cabundle: "true"
       labels:
@@ -10726,7 +10702,6 @@ metadata:
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
     provider.cluster.x-k8s.io/name: openstack


### PR DESCRIPTION
Builds on #293; you may want to review that one first.

openshift/machine-api-operator@9c20871740 (openshift/machine-api-operator#1174) added this capability to the machine-API analog of this manifest.  And openshift/cluster-capi-operator@e305541274 (openshift/cluster-capi-operator#143) annotated some cluster-API CredentialsRequests used for other  providers.  This commit catches cluster-API OpenStack up with those other changes.

There is a risk that tech-preview clusters updating into this change will have the CloudCredential capability implicitly enabled.  But because tech-preview clusters with the CloudCredential capability disabled were not installable, there should be no exposed clusters attempting those updates.