### PR TITLE
OCPBUGS-25859: CARRY: Add Snyk security scan config

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -3,5 +3,7 @@
 # https://docs.snyk.io/snyk-cli/commands/ignore
 exclude:
   global:
-    - vendor/**
-    - **/vendor/**
+    - "**/vendor/**"
+    - "hack/**"
+    - "test/**"
+    - "**/*_test.go"


### PR DESCRIPTION
In addition to vendor directories, we can ignore things that do not end up in the product.