### PR TITLE
OCPBUGS-33170: openshift: Set FallbackToLogsOnError on infra-cluster controller

### DIFF
--- a/openshift/kustomize/infracluster-controller/controller.yaml
+++ b/openshift/kustomize/infracluster-controller/controller.yaml
@@ -45,6 +45,7 @@ spec:
             privileged: false
             runAsUser: 65532
             runAsGroup: 65532
+          terminationMessagePolicy: FallbackToLogsOnError
       terminationGracePeriodSeconds: 10
       securityContext:
         runAsNonRoot: true

--- a/openshift/manifests/0000_30_cluster-api-provider-openstack_04_infrastructure-components.yaml
+++ b/openshift/manifests/0000_30_cluster-api-provider-openstack_04_infrastructure-components.yaml
@@ -17010,6 +17010,7 @@ data:
               privileged: false
               runAsGroup: 65532
               runAsUser: 65532
+            terminationMessagePolicy: FallbackToLogsOnError
           priorityClassName: system-cluster-critical
           securityContext:
             runAsNonRoot: true


### PR DESCRIPTION
This addresses only the infra-cluster-controller. For the primary CAPO controller I would like to fix this upstream and cherry-pick here: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2070