### PR TITLE
snyk: ignore md5 & SHA1 warnings for ORC images

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -8,3 +8,7 @@ exclude:
     - "hack/**"
     - "test/**"
     - "**/*_test.go"
+    # Here we skip warnings about the fact md5 and sha1 is being used to check images checksums.
+    # Ignoring these errors doesn't seem to work with the "ignore:" interface so let's just skip
+    # this file for now.
+    - 'internal/controllers/image/upload_helpers.go'

--- a/hack/tools/vendor/sigs.k8s.io/cluster-api-provider-openstack/.snyk
+++ b/hack/tools/vendor/sigs.k8s.io/cluster-api-provider-openstack/.snyk
@@ -8,3 +8,7 @@ exclude:
     - "hack/**"
     - "test/**"
     - "**/*_test.go"
+    # Here we skip warnings about the fact md5 and sha1 is being used to check images checksums.
+    # Ignoring these errors doesn't seem to work with the "ignore:" interface so let's just skip
+    # this file for now.
+    - 'internal/controllers/image/upload_helpers.go'


### PR DESCRIPTION
**What this PR does / why we need it**:

We allow to check SHA1 and md5 for Glance images, we can ignore these
security concerns.
