### PR TITLE
OCPBUGS-44959: Makefile changes for merge-bot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,15 @@ modules: ## Runs go mod to ensure proper vendoring.
 	go mod tidy
 	cd $(TOOLS_DIR); go mod tidy
 
+.PHONY: merge-bot
+merge-bot: full-vendoring generate ## Runs targets that help merge-bot to rebase downstream CAPO.
+
+.PHONY: full-vendoring
+full-vendoring: ## Runs commands that complete vendoring tasks for downstream CAPO.
+	go mod tidy && go mod vendor
+	cd $(TOOLS_DIR); go mod tidy; go mod vendor
+	cd $(REPO_ROOT)/openshift; go mod tidy; go mod vendor
+
 .PHONY: generate
 generate: templates generate-controller-gen generate-conversion-gen generate-go generate-manifests generate-api-docs ## Generate all generated code
 

--- a/Makefile
+++ b/Makefile
@@ -252,13 +252,17 @@ modules: ## Runs go mod to ensure proper vendoring.
 	cd $(TOOLS_DIR); go mod tidy
 
 .PHONY: merge-bot
-merge-bot: full-vendoring generate ## Runs targets that help merge-bot to rebase downstream CAPO.
+merge-bot: full-vendoring generate generate-openshift ## Runs targets that help merge-bot to rebase downstream CAPO.
 
 .PHONY: full-vendoring
 full-vendoring: ## Runs commands that complete vendoring tasks for downstream CAPO.
 	go mod tidy && go mod vendor
 	cd $(TOOLS_DIR); go mod tidy; go mod vendor
 	cd $(REPO_ROOT)/openshift; go mod tidy; go mod vendor
+
+.PHONY: generate-openshift
+generate-openshift:
+	$(MAKE) -C $(REPO_ROOT)/openshift generate
 
 .PHONY: generate
 generate: templates generate-controller-gen generate-conversion-gen generate-go generate-manifests generate-api-docs ## Generate all generated code


### PR DESCRIPTION
**What this PR does / why we need it**:

Both cherry-pick conflict because orc wasn't a thing yet.

- CARRY: Makefile: add `merge-bot` target
- CARRY: Makefile: add `generate-openshift`
