### PR TITLE
OCPBUGS-45387: Updating openstack-cluster-api-controllers-container image to be consistent with ART for 4.19

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.22-openshift-4.18
+  tag: rhel-9-release-golang-1.23-openshift-4.19

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy
@@ -38,7 +38,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
     -o manager
 
 # Production image
-FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/infracluster-controller .

--- a/hack/tools/vendor/sigs.k8s.io/cluster-api-provider-openstack/.ci-operator.yaml
+++ b/hack/tools/vendor/sigs.k8s.io/cluster-api-provider-openstack/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.22-openshift-4.18
+  tag: rhel-9-release-golang-1.23-openshift-4.19

--- a/hack/tools/vendor/sigs.k8s.io/cluster-api-provider-openstack/Dockerfile.rhel
+++ b/hack/tools/vendor/sigs.k8s.io/cluster-api-provider-openstack/Dockerfile.rhel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy
@@ -38,7 +38,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
     -o manager
 
 # Production image
-FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/infracluster-controller .


### PR DESCRIPTION
Supersedes https://github.com/openshift/cluster-api-provider-openstack/pull/344