### PR TITLE
OSASINFRA-3722: Deploy manifests for CustomNoUpgrade feature set also

### DIFF
--- a/openshift/kustomize/components/tech-preview/kustomization.yaml
+++ b/openshift/kustomize/components/tech-preview/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
-
 commonAnnotations:
-  release.openshift.io/feature-set: "TechPreviewNoUpgrade"
+  release.openshift.io/feature-set: "CustomNoUpgrade,TechPreviewNoUpgrade"

--- a/openshift/manifests/0000_30_cluster-api-provider-openstack_00_credentials-request.yaml
+++ b/openshift/manifests/0000_30_cluster-api-provider-openstack_00_credentials-request.yaml
@@ -5,7 +5,7 @@ metadata:
     capability.openshift.io/name: CloudCredential
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
   name: openshift-cluster-api-openstack
   namespace: openshift-cloud-credential-operator
 spec:

--- a/openshift/manifests/0000_30_cluster-api-provider-openstack_04_infrastructure-components.yaml
+++ b/openshift/manifests/0000_30_cluster-api-provider-openstack_04_infrastructure-components.yaml
@@ -8,7 +8,7 @@ data:
         controller-gen.kubebuilder.io/version: v0.16.4
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
         service.beta.openshift.io/inject-cabundle: "true"
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -601,7 +601,7 @@ data:
         controller-gen.kubebuilder.io/version: v0.16.5
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
         service.beta.openshift.io/inject-cabundle: "true"
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -6031,7 +6031,7 @@ data:
         controller-gen.kubebuilder.io/version: v0.16.5
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
         service.beta.openshift.io/inject-cabundle: "true"
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -9499,7 +9499,7 @@ data:
         controller-gen.kubebuilder.io/version: v0.16.5
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
         service.beta.openshift.io/inject-cabundle: "true"
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -9766,7 +9766,7 @@ data:
         controller-gen.kubebuilder.io/version: v0.16.5
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
         service.beta.openshift.io/inject-cabundle: "true"
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -12143,7 +12143,7 @@ data:
         controller-gen.kubebuilder.io/version: v0.16.5
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
         service.beta.openshift.io/inject-cabundle: "true"
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -14008,7 +14008,7 @@ data:
         controller-gen.kubebuilder.io/version: v0.16.5
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
         service.beta.openshift.io/inject-cabundle: "true"
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -15249,7 +15249,7 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
       name: capo-infracluster-controller
@@ -15261,7 +15261,7 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
       name: capo-manager
@@ -15273,7 +15273,7 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
       name: capo-infracluster-controller
@@ -15314,7 +15314,7 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
       name: capo-leader-election-role
@@ -15365,7 +15365,7 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
       name: capo-infracluster-controller
@@ -15386,7 +15386,7 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
       name: capo-infracluster-controller
@@ -15429,7 +15429,7 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
       name: capo-manager-role
@@ -15554,7 +15554,7 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
       name: capo-infracluster-controller-leader-election-rolebinding
@@ -15574,7 +15574,7 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
       name: capo-infracluster-controller-rolebinding
@@ -15594,7 +15594,7 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
       name: capo-leader-election-rolebinding
@@ -15614,7 +15614,7 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
       name: capo-infracluster-controller-rolebinding
@@ -15634,7 +15634,7 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
       name: capo-infracluster-controller-rolebinding
@@ -15653,7 +15653,7 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
       name: capo-manager-rolebinding
@@ -15672,7 +15672,7 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
         service.beta.openshift.io/serving-cert-secret-name: capo-webhook-service-cert
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -15691,7 +15691,7 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
         control-plane: capo-controller-manager
@@ -15708,7 +15708,7 @@ data:
           annotations:
             exclude.release.openshift.io/internal-openshift-hosted: "true"
             include.release.openshift.io/self-managed-high-availability: "true"
-            release.openshift.io/feature-set: TechPreviewNoUpgrade
+            release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
             target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
           labels:
             cluster.x-k8s.io/provider: infrastructure-openstack
@@ -15781,7 +15781,7 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
         control-plane: capo-infracluster-controller
@@ -15798,7 +15798,7 @@ data:
           annotations:
             exclude.release.openshift.io/internal-openshift-hosted: "true"
             include.release.openshift.io/self-managed-high-availability: "true"
-            release.openshift.io/feature-set: TechPreviewNoUpgrade
+            release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
             target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
           labels:
             cluster.x-k8s.io/provider: infrastructure-openstack
@@ -15858,7 +15858,7 @@ data:
       annotations:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
         service.beta.openshift.io/inject-cabundle: "true"
       labels:
         cluster.x-k8s.io/provider: infrastructure-openstack
@@ -15974,7 +15974,7 @@ metadata:
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
   labels:
     provider.cluster.x-k8s.io/name: openstack
     provider.cluster.x-k8s.io/type: infrastructure


### PR DESCRIPTION
As was done for the other providers previously [1]. This was achieved by
modifying 'kustomization.yaml' and running:

    make -C openshift generate

[1] https://github.com/openshift/cluster-capi-operator/pull/238
