### PR TITLE
OCPCLOUD-2857: Set infrastructureRef.Namespace in Cluster object

### DIFF
--- a/openshift/pkg/infraclustercontroller/openstackcluster.go
+++ b/openshift/pkg/infraclustercontroller/openstackcluster.go
@@ -462,6 +462,7 @@ func (r *OpenShiftClusterReconciler) ensureCAPICluster(ctx context.Context, log 
 	cluster.Spec.InfrastructureRef = &corev1.ObjectReference{
 		Kind:       gvk.Kind,
 		Name:       openStackCluster.Name,
+		Namespace:  openStackCluster.Namespace,
 		APIVersion: gvk.GroupVersion().String(),
 	}
 


### PR DESCRIPTION
Failing to set this breaks from CAPI v1.9 onwards.

/hold
