### PR TITLE
OCPCLOUD-3359: Add TLS substitutions

### DIFF
--- a/openshift/capi-operator-manifests/default/manifests.yaml
+++ b/openshift/capi-operator-manifests/default/manifests.yaml
@@ -9125,6 +9125,8 @@ spec:
         - --diagnostics-address=127.0.0.1:8080
         - --insecure-diagnostics=true
         - --feature-gates=PriorityQueue=${EXP_CAPO_PRIORITY_QUEUE:=false},AutoScaleFromZero=${EXP_CAPO_AUTOSCALE_FROM_ZERO:=false}
+        - --tls-min-version=${TLS_MIN_VERSION}
+        - --tls-cipher-suites=${TLS_CIPHER_SUITES}
         command:
         - /manager
         image: registry.ci.openshift.org/openshift:openstack-cluster-api-controllers

--- a/openshift/kustomization.yaml
+++ b/openshift/kustomization.yaml
@@ -11,3 +11,16 @@ images:
 - name: gcr.io/k8s-staging-capi-openstack/capi-openstack-controller
   newName: registry.ci.openshift.org/openshift
   newTag: openstack-cluster-api-controllers
+
+# Add TLS configuration args (substituted by cluster-capi-operator revisiongenerator)
+patches:
+- target:
+    kind: Deployment
+    name: capo-controller-manager
+  patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls-min-version=${TLS_MIN_VERSION}"
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls-cipher-suites=${TLS_CIPHER_SUITES}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Controller manager TLS options are now configurable: set the minimum TLS protocol version and cipher suites at runtime via environment-variable substitutions to control encryption settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->