### PR TITLE
OSPRH-33339: Add rebasebot post-rebase hook script

### DIFF
--- a/hack/rebasebot-helpers/post-rebase.sh
+++ b/hack/rebasebot-helpers/post-rebase.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# This script is run by rebasebot as a post-rebase hook during the rebase of
+# openshift/cluster-api-provider-openstack.
+# It replaces the merge-bot's --run-make flag which ran `make merge-bot`.
+
+set -e
+set -o pipefail
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "post-rebase hook requires a clean worktree" >&2
+    exit 1
+fi
+
+make merge-bot
+
+if [[ -z "$REBASEBOT_GIT_USERNAME" || -z "$REBASEBOT_GIT_EMAIL" ]]; then
+    author_flag=()
+else
+    author_flag=(--author="$REBASEBOT_GIT_USERNAME <$REBASEBOT_GIT_EMAIL>")
+fi
+
+if [[ -n $(git status --porcelain) ]]; then
+    git add -A
+    git commit "${author_flag[@]}" -q -m "UPSTREAM: <drop>: Run make merge-bot"
+fi


### PR DESCRIPTION
 Adds `hack/rebasebot-helpers/post-rebase.sh`, a post-rebase hook script for ShiftStacks migration from `merge-bot` to `rebasebot`.

  This replaces the merge-bot `--run-make` flag which ran `make merge-bot` after each rebase. The script runs `make merge-bot` (full-vendoring, generate, generate-openshift) and commits the results, following the pattern used by
  [cluster-capi-operator](https://github.com/openshift/cluster-capi-operator/tree/main/hack/rebasebot-hook-scripts).

  The rebasebot periodic configs in openshift/release will reference this script via:
  `--post-rebase-hook git:dest/main:hack/rebasebot-helpers/post-rebase.sh`

  The `git:dest/main:` prefix fetches the script from main, so all release branch jobs (4.16 through 5.1) will use it without needing the script on each branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated post-rebase hook that runs required merge-bot generation steps.
  * Ensures the working tree is clean before proceeding, and fails fast if preconditions aren’t met.
  * If changes are produced, stages them and creates a quiet commit with a standardized `UPSTREAM: <drop>: Run make merge-bot` message, using optional author details from environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->